### PR TITLE
Adding ops file to create jumpbox user that can be used to ssh

### DIFF
--- a/jumpbox.yml
+++ b/jumpbox.yml
@@ -1,0 +1,24 @@
+# Add os-conf release if not there or replace
+- type: replace
+  path: /releases/name=os-conf?
+  value:
+    name: os-conf
+    version: 12
+    url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=12
+    sha1: af5a2c9f228b9d7ec4bd051d71fef0e712fa1549
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/-
+  value:
+    name: user_add
+    release: os-conf
+    properties:
+      users:
+      - name: jumpbox
+        public_key: ((jumpbox_ssh.public_key))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: jumpbox_ssh
+    type: ssh


### PR DESCRIPTION
Creates jumpbox user that will be used to ssh. 
Found this very useful when troubleshooting isolated environment in a locked down environment. 