### PR TITLE
Add ops files to support external worker deployments

### DIFF
--- a/bosh-deploy.yml
+++ b/bosh-deploy.yml
@@ -1,0 +1,55 @@
+---
+- type: remove
+  path: /cloud_provider
+
+- type: remove
+  path: /instance_groups/name=concourse/resource_pool
+
+- type: replace
+  path: /instance_groups/name=concourse/vm_type?
+  value: large
+
+- type: remove
+  path: /instance_groups/name=concourse/persistent_disk_pool
+
+- type: replace
+  path: /instance_groups/name=concourse/disk_type?
+  value: default
+
+- type: replace
+  path: /instance_groups/name=concourse/azs?
+  value: [z1]
+
+- type: remove
+  path: /resource_pools
+
+- type: remove
+  path: /disk_pools
+
+- type: remove
+  path: /networks
+
+- type: remove
+  path: /variables/name=mbus_bootstrap_password
+
+- type: remove
+  path: /variables/name=postgres_password
+
+- type: replace
+  path: /update?
+  value:
+    canaries: 0
+    max_in_flight: 1
+    canary_watch_time: 30000-180000
+    update_watch_time: 30000-180000
+
+- type: replace
+  path: /stemcells?/-
+  value:
+    alias: default
+    os: ubuntu-trusty
+    version: "((stemcell_version))"
+
+- type: replace
+  path: /instance_groups/name=concourse/stemcell?
+  value: default

--- a/external-worker.yml
+++ b/external-worker.yml
@@ -1,0 +1,51 @@
+---
+- type: replace
+  path: /name
+  value: concourse-worker
+
+- type: remove
+  path: /instance_groups/name=concourse/jobs/name=atc
+
+- type: remove
+  path: /instance_groups/name=concourse/jobs/name=tsa
+
+- type: remove
+  path: /instance_groups/name=concourse/jobs/name=postgresql
+
+- type: replace
+  path: /instance_groups/name=concourse/instances
+  value: ((num_workers))
+
+- type: remove
+  path: /instance_groups/name=concourse/disk_type
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/tsa?/host?
+  value: ((tsa_host))
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/tsa?/host_public_key?
+  value: ((tsa_public_key))
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/tsa?/private_key?
+  value: ((worker_private_key))
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/garden?/forward_address?
+  value: 127.0.0.1:7777
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/garden?/listen_network?
+  value: tcp
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/garden?/listen_address?
+  value: 0.0.0.0:7777
+
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/baggageclaim?/forward_address?
+  value: 127.0.0.1:7788
+
+- type: remove
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/baggageclaim/url

--- a/infrastructures/gcp/cloud-config.yml
+++ b/infrastructures/gcp/cloud-config.yml
@@ -1,0 +1,52 @@
+azs:
+- name: z1
+  cloud_properties:
+    zone: ((zone))
+- name: z2
+  cloud_properties:
+    zone: ((zone))
+- name: z3
+  cloud_properties:
+    zone: ((zone))
+
+vm_types:
+- name: default
+  cloud_properties:
+    machine_type: n1-standard-2
+    root_disk_size_gb: 20
+    root_disk_type: pd-ssd
+- name: large
+  cloud_properties:
+    machine_type: n1-standard-2
+    root_disk_size_gb: 50
+    root_disk_type: pd-ssd
+
+disk_types:
+- name: default
+  disk_size: 3000
+- name: large
+  disk_size: 50_000
+
+networks:
+- name: default
+  type: manual
+  subnets:
+  - range: ((internal_cidr))
+    gateway: ((internal_gw))
+    azs: [z1, z2, z3]
+    dns: [8.8.8.8]
+    reserved: ((reserved_range))
+    cloud_properties:
+      network_name: ((network))
+      subnetwork_name: ((subnetwork))
+      ephemeral_external_ip: true
+      tags: ((tags))
+- name: vip
+  type: vip
+
+compilation:
+  workers: 5
+  reuse_compilation_vms: true
+  az: z1
+  vm_type: default
+  network: default

--- a/tagged-worker.yml
+++ b/tagged-worker.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=groundcrew/properties/tags?
+  value: ((tags))


### PR DESCRIPTION
bosh-deploy.yml:
- switch from create-env manifest to deploy manifest

infrastructure/gcp/cloud-config.yml
- provide basic cloud-config.yml for concourse worker deployment

external-worker.yml:
- change deployment name
- remove non-workder jobs
- configure groundcrew to forward baggaclaim and garden traffic

tagged-worker.yml:
- allow tagging of workers