### PR TITLE
Use a range that donesnt overlap with the cf one in bosh lite

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -22,8 +22,8 @@ bosh -e $BOSH_ENVIRONMENT deploy -d concourse concourse.yml \
   --vars-store cluster-creds.yml \
   -o operations/static-web.yml \
   -o operations/no-auth.yml \
-  --var web_ip=10.244.15.2 \
-  --var external_url=http://10.244.15.2:8080 \
+  --var web_ip=10.244.16.2 \
+  --var external_url=http://10.244.16.2:8080 \
   --var network_name=concourse \
   --var web_vm_type=concourse \
   --var db_vm_type=concourse \

--- a/cluster/cloud_configs/vbox.yml
+++ b/cluster/cloud_configs/vbox.yml
@@ -6,13 +6,13 @@ networks:
 - name: concourse
   subnets:
   - az: z1
-    gateway: 10.244.15.1
-    range: 10.244.15.0/30
-    static:
-    - 10.244.15.2
-  - az: z1
     gateway: 10.244.16.1
-    range: 10.244.16.0/24
+    range: 10.244.16.0/30
+    static:
+    - 10.244.16.2
+  - az: z1
+    gateway: 10.244.17.1
+    range: 10.244.17.0/24
 
 vm_types:
 - name: concourse


### PR DESCRIPTION
I run both CF and Concourse in Bosh Lite for fun and profit.

The CF Bosh Lite [cloud config](https://github.com/cloudfoundry/cf-deployment/blob/master/iaas-support/bosh-lite/cloud-config.yml#L27) steals `10.244.0.0/20`, i.e `10.244.0.0`-`10.244.15.255 ` which causes network overlap errors when deploying concourse after CF.

This PR just bumps the network for Concourse to `10.244.16.0/30` and `10.244.17.0/24`