### PR TITLE
Cluster deploy due to tsa host key issue

### DIFF
--- a/cluster/concourse.yml
+++ b/cluster/concourse.yml
@@ -42,7 +42,7 @@ instance_groups:
     name: tsa
     properties:
       log_level: debug
-      host_key: ((tsa_host_key))
+      host_key: ((tsa_host_key.private_key))
       token_signing_key: ((token_signing_key))
       authorized_keys: [((worker_key.public_key))]
 


### PR DESCRIPTION
Deploying TSA fails.

```
web/2b8cea0e-889c-48e0-a49d-007f86618b4e:~$ head -n 1 /var/vcap/sys/log/tsa/tsa.stderr.log
failed to configure SSH server: ssh: no key found
```

```
web/2b8cea0e-889c-48e0-a49d-007f86618b4e:~$ sudo cat /var/vcap/jobs/tsa/config/host_key
{"private_key"=>"-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAzYsuZ4JLiRBL+ddXoteLjpVhNI7HQ+4QK9YnIVbslm461gd3\n8TI6iSnc5Oe4DbV5N5n1FX9vbvI4y5R+dY//FlGnaAcfYlCnOzPXqdET+/zOFMUr\nKvxInrSlDl9poHXz96JllHdeCfF90LB76IJ21j/i8Pt/1TkxGIQi95fQVBSo7A+o\nKU6gJnFUJ28foCzcQ3SPPUVYqLr/zGANtB0Sep3jVCpZhi04rl/p+mPOgOlVuzzK\nOHBbsciuXBeC+9TOKD2khZ3sNoM3e3+/zp6LfSuqgps+IJOBwutsUVC7sDT6qyRV\nv3ZtOmeWdbDurDEqJRu+T/6Tm82AMNB3H8TtSwIDAQABAoIBAGOUpbPCPWQ3QAfY\nG34qXVOD7acv8Txo7u69/xE48sBiwSCGV8bEJfXkET/ZP6Nso0Cb11BGAC/JLFj9\nJVNBoz0l7CwLH1pbZtnY4QhF4h+4OAN6DtLxjSFOtZTEBwGVg9AanooSVr4MgH8F\nsdJQutBL/V/xCNq9rZqKEgLQSz8gMIuUHr94n4YFW5v3U9rdCM3fPgtrhkVXbyCN\ngJRgBN6Uj5AoKUw8gNn0b73KIobVkz34SCtoToRv8EFFaaY8G0c9JXDZUV+eFTcY\nlh3iJyQzzVInRuJrArZFTH+/SfBQIAv8UKEjXff/bsQf4YuWDHv37KXBzIsAlYOJ\nurv+Q1ECgYEA105IpfyUxsWt8H5j7tEMnm2Bi5CD11/tps//qSHqmvXpcW9dZxZL\nCHunkI8EWXMpnxz6pL8EGCOapOrKp1DYFiDCTnLYc3cJNK26mV41prUtysoEPhgS\nQfF+gCTA2INbnqjILApz3Gl8Rt6c78OBcsjR1o3pr6DbfrL76y57qAMCgYEA9GSM\n/pT/lXPIwQYze0qG7FadNAvBKSr0zYhntGa30ISjC1qn5SNtG8mi2TIlAgXayZPO\nCrVhs8pv40OJ7xgJpblZtYlDaOvbuYEFw2JzcpX2fgZ0d5T3eOA0UvD8+pGDB12e\nhbkz4nTY+Fa5Y6xbL5mYLnRs/2ta4bs9/zvd1xkCgYBks/Pc1xfLJNinXKZnJBYP\n384wtgZEbVTdqfm9ZOSzWAO5D8qTFeVAcX29ancxU2ELT+WXutQyaizBqCPjQDfh\nma7oPGUrFGkU35EgfOUBNUrWx8hWNrILb+WoEAi2/DGVMwJ1PupUFG6RQzwKFNpu\nEqm6/aNohwdC6npT1Oj3ewKBgQDNK5j+pUHISzLPcZBIwjFxOemx5uhb0ldAMXK2\njcFlSeTDRHFNOaeAu49+fc153EZoEjDY5ptGX/38shebZPe8bFW2xKyV6eRF4N5g\nwEchfGo6NNsUBTiY/siOlQgcp4pz5ZGOvAOl6ui32765wdmvpWeQIGfdKlhax2Ht\n42mDCQKBgDdZ1h4tZD1KCXVLszRvrVcyaK2tzLzONe+KGSzvw0DQ5dXvLgW5qN6k\nHoxp6zik7Os/gDDg7C9QhpmGoqyc8cIiqn1yuhTVID/c16jvg9neCyB+rRmCxlgP\nsX4oH5dx5fkAm2QPOQNJVojNs+BiMbResvJ1maezDHVJEKygSyae\n-----END RSA PRIVATE KEY-----\n", "public_key"=>"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNiy5ngkuJEEv511ei14uOlWE0jsdD7hAr1ichVuyWbjrWB3fxMjqJKdzk57gNtXk3mfUVf29u8jjLlH51j/8WUadoBx9iUKc7M9ep0RP7/M4UxSsq/EietKUOX2mgdfP3omWUd14J8X3QsHvognbWP+Lw+3/VOTEYhCL3l9BUFKjsD6gpTqAmcVQnbx+gLNxDdI89RViouv/MYA20HRJ6neNUKlmGLTiuX+n6Y86A6VW7PMo4cFuxyK5cF4L71M4oPaSFnew2gzd7f7/Onot9K6qCmz4gk4HC62xRULuwNPqrJFW/dm06Z5Z1sO6sMSolG75P/pObzYAw0HcfxO1L\n", "public_key_fingerprint"=>"f8:ee:0a:ea:05:53:d7:ff:25:31:b3:71:d9:dc:39:c4"}
```

According to [tsa job](https://github.com/concourse/concourse/blob/master/jobs/tsa/templates/host_key.erb) the host key should be a private key.

In [concourse.yml](https://github.com/concourse/concourse-deployment/blob/master/cluster/concourse.yml#L45) we are passing a hash of private_key, public_key and public_key_fingerprint

This PR fixes this.