### PR TITLE
Add external worker base manifest

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -38,3 +38,34 @@ with `fly`:
 ```shell
 fly -t ci login -c http://10.244.15.2:8080
 ```
+
+## External Concourse worker
+
+In case you have a distributed setup with external concourse workers deployed on another BOSH 
+you can deploy those with:
+```shell
+bosh -e $BOSH_ENVIRONMENT deploy -d concourse-worker external-worker.yml \
+  -l ../versions.yml \
+  -v network_name=concourse \
+  -v worker_vm_type=concourse-workers \
+  -v instances=2 \
+  -v azs=[z1] \
+  -v deployment_name=concourse-worker \
+  -v tsa_host=10.244.15.2 \
+  -v worker_tags=[tags] \
+  -l <path/to/secrets.yml> 
+```
+
+The `secrets.yml` file has to contain the public tsa host key of the concourse master and the worker private 
+key:
+
+```yaml
+tsa_host_key:
+  public_key: <public_key>
+
+worker_key:
+  private_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
+```

--- a/cluster/external-worker.yml
+++ b/cluster/external-worker.yml
@@ -1,0 +1,59 @@
+name: ((deployment_name))
+
+releases:
+- name: concourse
+  version: ((concourse_version))
+  sha1: ((concourse_sha1))
+  url: https://bosh.io/d/github.com/concourse/concourse?v=((concourse_version))
+- name: garden-runc
+  version: ((garden_runc_version))
+  sha1: ((garden_runc_sha1))
+  url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=((garden_runc_version))
+
+stemcells:
+- alias: trusty
+  os: ubuntu-trusty
+  version: latest
+
+instance_groups:
+- name: worker
+  instances: ((instances))
+  azs: ((azs))
+  vm_type: ((worker_vm_type))
+  stemcell: trusty
+  networks: [{name: ((network_name))}]
+  jobs:
+  - name: groundcrew
+    release: concourse
+    consumes: {baggageclaim: {from: worker-baggageclaim}}
+    properties:
+      tags: ((worker_tags))
+      tsa:
+        host: ((tsa_host))
+        port: 2222
+        host_public_key: ((tsa_host_key.public_key))
+        worker_key: ((worker_key))
+      garden:
+        forward_address: 127.0.0.1:7777
+      baggageclaim:
+        forward_address: 127.0.0.1:7788
+  - name: baggageclaim
+    release: concourse
+    provides: {baggageclaim: {as: worker-baggageclaim}}
+    properties:
+      log_level: debug
+      bind_ip: 127.0.0.1
+  - name: garden
+    release: garden-runc
+    properties:
+      garden:
+        forward_address: 127.0.0.1:7777
+        listen_network: tcp
+        listen_address: 0.0.0.0:7777
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  serial: false
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000

--- a/cluster/external-worker.yml
+++ b/cluster/external-worker.yml
@@ -49,7 +49,7 @@ instance_groups:
       garden:
         forward_address: 127.0.0.1:7777
         listen_network: tcp
-        listen_address: 0.0.0.0:7777
+        listen_address: 127.0.0.1:7777
 
 update:
   canaries: 1


### PR DESCRIPTION
This adds a base manifest to deploy external workers that are managed by a different BOSH than the concourse master. It was cumbersome to derive this from https://github.com/concourse/concourse-deployment/blob/master/cluster/concourse.yml removing a lot of things, so instead this is a new base manifest.

This is basically a new minimal incarnation of https://github.com/concourse/concourse-deployment/pull/16.