### PR TITLE
opsfile to set an ephemeral disk VM extension on the worker

### DIFF
--- a/cluster/operations/worker-ephemeral-disk.yml
+++ b/cluster/operations/worker-ephemeral-disk.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/vm_extensions?/-
+  value: ((worker_ephemeral_disk))


### PR DESCRIPTION
This is necessary to run resources and tasks with large docker images

1. consult your cloud-config for named ephemeral disk configs.

2. then apply this opsfile and set the bosh variable, e.g.

```yaml
worker_ephemeral_disk: 100GB_ephemeral_disk
```