### PR TITLE
Use different variable for external worker network name

### DIFF
--- a/cluster/external-worker.yml
+++ b/cluster/external-worker.yml
@@ -21,7 +21,7 @@ instance_groups:
   azs: ((azs))
   vm_type: ((worker_vm_type))
   stemcell: trusty
-  networks: [{name: ((network_name))}]
+  networks: [{name: ((external_worker_network_name))}]
   jobs:
   - name: groundcrew
     release: concourse


### PR DESCRIPTION
- This allows one vars file to be shared between the main deployment and
the external worker deployment
