### PR TITLE
operations file to allow for deployment when no direct internet access

### DIFF
--- a/cluster/operations/no-internet-access.yml
+++ b/cluster/operations/no-internet-access.yml
@@ -1,0 +1,22 @@
+# Local releases when deployment is in an environment with no Internet access
+
+- type: replace
+  path: /releases/name=concourse/url
+  value: file://((concourse_release))
+
+- type: remove
+  path: /releases/name=concourse/sha1
+
+- type: replace
+  path: /releases/name=garden-runc/url
+  value: file://((garden_runc_release))
+
+- type: remove
+  path: /releases/name=garden-runc/sha1
+
+- type: replace
+  path: /releases/name=postgres/url
+  value: file://((postgres_release))
+
+- type: remove
+  path: /releases/name=postgres/sha1


### PR DESCRIPTION
When deploying on-prem with some customers direct access to the internet is restricted/blocked therefore a need often exists to deploy using release that have already been downloaded and transferred internally. This ops file is to update the deployment to  obtain the various bosh releases from a local directory rather than from the Internet.

I have been using this with a customer already and done multiple deployments with it. 