### PR TITLE
Adds an ops file for those using BBL lbs

### DIFF
--- a/cluster/operations/bbl-lbs.yml
+++ b/cluster/operations/bbl-lbs.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=web/vm_extensions?/-
+  value: lb
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/bind_port?
+  value: 80
+- type: replace

--- a/cluster/operations/bbl-lbs.yml
+++ b/cluster/operations/bbl-lbs.yml
@@ -4,4 +4,3 @@
 - type: replace
   path: /instance_groups/name=web/jobs/name=atc/properties/bind_port?
   value: 80
-- type: replace


### PR DESCRIPTION
Hello fellow aeronauts!

We maintain instructions in the bosh-bootloader repo for an easy way to install BOSH+concourse with the load balancers created by bbl:
https://github.com/cloudfoundry/bosh-bootloader/blob/master/docs/concourse.md

It would be even simpler if they could run this without editing any files, and just use some file in this repo. I'm open to a different name for the file (like "external-lbs.yml"), or a different name for the load balancer (like "concourse-web"), but we forward port 80 and we use a VM extension to add loadbalancers to IaaS agnostic VM types and those are opinions we like.