### PR TITLE
Add tls-variables ops-file for missing vars in tls.yml

### DIFF
--- a/cluster/operations/tls-vars.yml
+++ b/cluster/operations/tls-vars.yml
@@ -1,0 +1,16 @@
+- type: replace
+  path: /variables/-
+  value:
+    name: atc_ca
+    type: certificate
+    options:
+      is_ca: true
+      common_name: atcCA
+
+- type: replace
+  path: /variables/-
+  value:
+    name: atc_tls
+    type: certificate
+    options:
+      ca: atc_ca


### PR DESCRIPTION
There are variables required in the `tls.yml` ops-file and these can be generated by bosh by adding them to `variables`. If you prefer that the normative case is users providing their own cert/key, we have made a PR for adding tls variables as a separate ops-file. If you think we can add it to the main ops-file, we can make that change and perhaps make the common name a configurable var by the user?

cc @rowanjacobs