### PR TITLE
Make static-web.yml work for 2+ IPs

### DIFF
--- a/cluster/operations/static-web.yml
+++ b/cluster/operations/static-web.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /instance_groups/name=web/networks/0/static_ips?
+  path: /instance_groups/name=web/networks/0/static_ips/
   value: [((web_ip))]


### PR DESCRIPTION
Currently if you try to use this ops file when you have more than 1 static IP it does not process correctly.

This edit fixes that and allows you to specify your static IPs in your params file like:
```
web_ip:
- 10.0.0.10
- 10.0.1.10
```