### PR TITLE
adding ops file to configure the port ATC uses

### DIFF
--- a/cluster/operations/http-proxy.yml
+++ b/cluster/operations/http-proxy.yml
@@ -7,3 +7,13 @@
 - type: replace
   path: /instance_groups/name=worker/jobs/name=groundcrew/properties/no_proxy?
   value: ((no_proxy)) # --var no_proxy='["localhost", "127.0.0.1", "example.com", "domain.com:8080"]'
+# Now do the same for garden:
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=garden/properties/garden/http_proxy?
+  value: ((proxy_url))
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=garden/properties/garden/https_proxy?
+  value: ((proxy_url))
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=garden/properties/garden/no_proxy?
+  value: ((no_proxy)) # --var no_proxy='["localhost", "127.0.0.1", "example.com", "domain.com:8080"]'

--- a/cluster/operations/use-port.yml
+++ b/cluster/operations/use-port.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/bind_port?
+  value: ((external_port))


### PR DESCRIPTION
I added an ops file to configure the port that ATC uses.  I'm running concourse in a home lab with no load balancer, so don't want to use 8080, and instead, use 80.

Added configuration so others can override the port.