### PR TITLE
Garden requires a proxy property to be set as well as ground crew.

### DIFF
--- a/cluster/operations/http-proxy.yml
+++ b/cluster/operations/http-proxy.yml
@@ -7,3 +7,13 @@
 - type: replace
   path: /instance_groups/name=worker/jobs/name=groundcrew/properties/no_proxy?
   value: ((no_proxy)) # --var no_proxy='["localhost", "127.0.0.1", "example.com", "domain.com:8080"]'
+# Now do the same for garden:
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=garden/properties/garden/http_proxy?
+  value: ((proxy_url))
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=garden/properties/garden/https_proxy?
+  value: ((proxy_url))
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=garden/properties/garden/no_proxy?
+  value: ((no_proxy)) # --var no_proxy='["localhost", "127.0.0.1", "example.com", "domain.com:8080"]'


### PR DESCRIPTION
We ran into an issue at a customer - it looks like you can't pull docker images through a proxy without setting the proxies in garden as well as groundcrew.

http://bosh.io/jobs/garden?source=github.com/cloudfoundry/garden-runc-release&version=1.11.1#p=garden.http_proxy