### PR TITLE
adding ops file to configure the port ATC uses

### DIFF
--- a/cluster/operations/use-port.yml
+++ b/cluster/operations/use-port.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/bind_port?
+  value: ((external_port))


### PR DESCRIPTION
I added an ops file to configure the port that ATC uses. I'm running concourse in a home lab with no load balancer, so don't want to use 8080, and instead, use 80.

Added configuration so others can override the port.

(new pull request to remove the extra commit in #50)
