### PR TITLE
Fix param for client_cert in vault tls cert auth

### DIFF
--- a/cluster/operations/vault-tls-cert-auth.yml
+++ b/cluster/operations/vault-tls-cert-auth.yml
@@ -5,6 +5,6 @@
     tls:
       ca_cert:
         certificate: ((vault_cert.ca))
-      client_cert: ((vault_cert))
+      client_cert: ((vault_cert.client))
     auth:
       backend: cert


### PR DESCRIPTION
I tried to deploy with `cluster/operations/vault-tls-cert-auth.yml`.
But, an error occurred.
```
Using deployment 'concourse'
[CLI] 2018/05/02 16:10:42 ERROR - Panic: interface conversion: interface {} is string, not map[interface {}]interface {}
********************
goroutine 1 [running]:
runtime/debug.Stack(0x984b80, 0xc42030edc0, 0x4f)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x79
main.handlePanic()
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/main.go:110 +0x224
panic(0x8fdb40, 0xc420377240)
        /usr/local/go/src/runtime/panic.go:458 +0x243
github.com/cloudfoundry/bosh-cli/cmd.Cmd.Execute.func1(0xc42024c188)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/cmd/cmd.go:47 +0xe7
panic(0x8fdb40, 0xc420377240)
        /usr/local/go/src/runtime/panic.go:458 +0x243
github.com/cloudfoundry/bosh-cli/director/template.StaticVariables.processed(0xc42022a570, 0x0)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/director/template/static_vars.go:40 +0x340
github.com/cloudfoundry/bosh-cli/director/template.StaticVariables.Get(0xc42022a570, 0xc42030e9c0, 0x11, 0xc4204a31c8, 0x8, 0x0, 0x0, 0xc42030e9c0, 0x11, 0x0, ...)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/director/template/static_vars.go:12 +0x2f
github.com/cloudfoundry/bosh-cli/director/template.MultiVars.Get(0xc420219220, 0x2, 0x2, 0xc42030e9c0, 0x11, 0xc4204a31c8, 0x8, 0x0, 0x0, 0x11, ...)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/director/template/multi_vars.go:15 +0x78
github.com/cloudfoundry/bosh-cli/director/template.(*MultiVars).Get(0xc420219260, 0xc42030e9c0, 0x11, 0xc4204a31c8, 0x8, 0x0, 0x0, 0x0, 0xc420379e30, 0xc420379e60, ...)
        <autogenerated>:3 +0x91
github.com/cloudfoundry/bosh-cli/director/template.varsTracker.Get(0xefd280, 0xc420219260, 0xc4200ba6c0, 0x4, 0x4, 0x0, 0xc420378db0, 0xc420378e10, 0xc420378e40, 0xc42030e9c0, ...)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/director/template/template.go:240 +0x378
github.com/cloudfoundry/bosh-cli/director/template.(*varsTracker).ExtractDefinitions(0xc420017130, 0x8e88c0, 0xc42022a6c0, 0x114b4b0, 0x0)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/director/template/template.go:281 +0x1c8
github.com/cloudfoundry/bosh-cli/director/template.Template.interpolateRoot(0xc4202f5000, 0x9c0, 0xe00, 0x8e88c0, 0xc42022a6c0, 0xefd280, 0xc420219260, 0x0, 0x0, 0x0, ...)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/director/template/template.go:69 +0xa9
github.com/cloudfoundry/bosh-cli/director/template.Template.Evaluate(0xc4202f5000, 0x9c0, 0xe00, 0xefd280, 0xc420219260, 0xef8c00, 0xc4202192a0, 0x0, 0x0, 0x0, ...)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/director/template/template.go:44 +0x2b3
github.com/cloudfoundry/bosh-cli/cmd.DeployCmd.Run(0xf04f60, 0xc42000ff00, 0xf07f60, 0xc420092280, 0xef7980, 0xc42022a540, 0xf07860, 0xc42000ff40, 0xc4202f5000, 0x9c0, ...)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/cmd/deploy.go:32 +0x162
github.com/cloudfoundry/bosh-cli/cmd.Cmd.Execute(0xac7e60, 0x90747c, 0xe, 0x7ffeefbff070, 0xd, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/cmd/cmd.go:296 +0x723a
main.main()
        /tmp/build/a9832f70/gopath/src/github.com/cloudfoundry/bosh-cli/main.go:35 +0x75d

********************
Exit code 1
```

So. I fix the param.