### PR TITLE
Use correct variable, `external_worker_network_name`

### DIFF
--- a/cluster/README.md
+++ b/cluster/README.md
@@ -42,22 +42,22 @@ fly -t ci login -c http://10.244.15.2:8080
 
 ## External Concourse worker
 
-In case you have a distributed setup with external concourse workers deployed on another BOSH 
+In case you have a distributed setup with external concourse workers deployed on another BOSH
 you can deploy those with:
 ```shell
 bosh -e $BOSH_ENVIRONMENT deploy -d concourse-worker external-worker.yml \
   -l ../versions.yml \
-  -v network_name=concourse \
+  -v external_worker_network_name=concourse \
   -v worker_vm_type=concourse-workers \
   -v instances=2 \
   -v azs=[z1] \
   -v deployment_name=concourse-worker \
   -v tsa_host=10.244.15.2 \
   -v worker_tags=[tags] \
-  -l <path/to/secrets.yml> 
+  -l <path/to/secrets.yml>
 ```
 
-The `secrets.yml` file has to contain the public tsa host key of the concourse master and the worker private 
+The `secrets.yml` file has to contain the public tsa host key of the concourse master and the worker private
 key:
 
 ```yaml


### PR DESCRIPTION
The README for the external worker refers to an incorrect variable,
`network_name`. The correct variable is `external_worker_network_name`.
`network_name` is the correct variable when you're not using external
workers.

Also, deleted trailing whitespace on several lines.

fixes:
```
Task 707 | 00:52:54 | Error: - Failed to find variable '/bosh-vsphere-ipv4/concourse-worker/external_worker_network_name' from config server: HTTP Code '404', Error: 'The request could not be completed because the credential does not exist or you do not have sufficient authorization.'
```