### PR TITLE
Add opsfile for setting build log retention

### DIFF
--- a/cluster/operations/build-log-retention.yml
+++ b/cluster/operations/build-log-retention.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/build_log_retention?
+  value:
+    default: ((build_logs_default))
+    maximum: ((build_logs_maximum))


### PR DESCRIPTION
Hi.
I add opsfile for [build log retention](https://bosh.io/jobs/atc?source=github.com/concourse/concourse&version=3.13.0#p%3dbuild_log_retention).

