### PR TITLE
Add common_name to generated ATC certificate

### DIFF
--- a/cluster/operations/tls-vars.yml
+++ b/cluster/operations/tls-vars.yml
@@ -13,4 +13,5 @@
     name: atc_tls
     type: certificate
     options:
+      common_name: ((external_hostname))
       ca: atc_ca


### PR DESCRIPTION
The `tls-vars.yml` operations file won't work as written, as it doesn't allow you to specify a `common_name`.

> Error: Config Server failed to generate value for '/bosh-bbl-env-saimaa-2018-07-30t17-54z/concourse/atc_tls' with type 'certificate'. HTTP Code '400', Error: 'At least one subject value, such as common name or organization, must be defined to generate the certificate. Please update and retry your request.

This adds a new `external_hostname` variable that gets placed in the common name.

There is a little duplication, as we now have `external_url` (expected to contain a scheme and optionally a port) and `external_hostname`, but any attempt to combine the two variables leaves the user with less flexibility.