### PR TITLE
fixing github var naming.

### DIFF
--- a/cluster/operations/github-auth.yml
+++ b/cluster/operations/github-auth.yml
@@ -6,12 +6,12 @@
 
 - type: replace
   path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/github/users
-  value: ((main_team.github.users))
+  value: ((main_team.github_users))
 
 - type: replace
   path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/github/orgs
-  value: ((main_team.github.orgs))
+  value: ((main_team.github_orgs))
 
 - type: replace
   path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/github/teams
-  value: ((main_team.github.teams))
+  value: ((main_team.github_teams))


### PR DESCRIPTION
BOSH is trying to interpolate the fields as actual canoncial paths
within the YAML syntax. by replacing `github.x` with `github_x`, the
variables can be interpolated and deployed properly.

fixes #79

Signed-off-by: Mike Lloyd <mike@reboot3times.org>