### PR TITLE
Add operator to change dns servers for lite deployment

### DIFF
--- a/lite/operations/dns.yml
+++ b/lite/operations/dns.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /networks/name=default/subnets/0/dns
+  value: ((internal_dns))


### PR DESCRIPTION
Adds the dns operator from `bosh-deployment` which allows changing the dns servers.