### PR TITLE
Update windows worker variable in ops file for consistency

### DIFF
--- a/cluster/operations/windows-worker.yml
+++ b/cluster/operations/windows-worker.yml
@@ -12,7 +12,7 @@
     instances: 1
     vm_type: ((windows_worker_vm_type))
     stemcell: windows
-    networks: [{name: ((network))}]
+    networks: [{name: ((network_name))}]
     azs: [z1]
     jobs:
     - name: houdini-windows

--- a/cluster/operations/windows-worker.yml
+++ b/cluster/operations/windows-worker.yml
@@ -12,7 +12,7 @@
     instances: 1
     vm_type: ((windows_worker_vm_type))
     stemcell: windows
-    networks: [{name: private}]
+    networks: [{name: ((network))}]
     azs: [z1]
     jobs:
     - name: houdini-windows


### PR DESCRIPTION
Update windows worker ops file to use a variable so it is consistent with primary deployment manifest and cloud-config.