### PR TITLE
Add UAA job and use it as the OAuth provider

### DIFF
--- a/cluster/operations/add-main-team-oauth-users.yml
+++ b/cluster/operations/add-main-team-oauth-users.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/oauth
+  value:
+    users: ((main_team_oauth_users))

--- a/cluster/operations/postgres-link.yml
+++ b/cluster/operations/postgres-link.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/provides?
+  value:
+    postgres: {as: db}

--- a/cluster/operations/uaa-generic-oauth-provider.yml
+++ b/cluster/operations/uaa-generic-oauth-provider.yml
@@ -1,0 +1,36 @@
+# Enable UAA as ATC's generic_oauth provider
+# Please add uaa.yml before this ops file
+
+# update UAA job by adding new client
+- type: replace
+  path: /instance_groups/name=web/jobs/name=uaa/properties/uaa/clients?/concourse_generic_oauth_client
+  value:
+    id: concourse_generic_oauth_client
+    secret: ((concourse_generic_oauth_client_secret))
+    override: true
+    scope: openid,email,profile,roles
+    authorized-grant-types: "authorization_code,refresh_token"
+    access-token-validity: 3600
+    refresh-token-validity: 7200
+    redirect-uri: https://((web_ip))/sky/issuer/callback
+
+# integrate ATC by adding generic_oauth part
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/generic_oauth?
+  value:
+    auth_url: "https://((web_ip)):8443/oauth/authorize"
+    ca_cert: ((atc_ca.ca))
+    client_id: concourse_generic_oauth_client
+    client_secret: ((concourse_generic_oauth_client_secret))
+    display_name: "UAA OAuth Provider"
+    groups_key: []
+    scopes: []
+    token_url: "https://((web_ip)):8443/oauth/token"
+    userinfo_url: "https://((web_ip)):8443/userinfo"
+
+# variables
+- type: replace
+  path: /variables/name=concourse_generic_oauth_client_secret?
+  value:
+    name: concourse_generic_oauth_client_secret
+    type: password

--- a/cluster/operations/uaa.yml
+++ b/cluster/operations/uaa.yml
@@ -1,0 +1,113 @@
+# release
+- type: replace
+  path: /releases/-
+  value:
+    name: uaa
+    url: https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=((uaa_version))
+    sha1: ((uaa_sha1))
+    version: ((uaa_version))
+
+# update postgres job to have uaa database
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/databases/-
+  value:
+    name: *uaa_db
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
+  value: 
+    name: *uaa_db
+    password: *uaa_db_passwd
+
+# add UAA job to web instance group
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    name: uaa
+    release: uaa
+    consumes: {database: {from: db}}
+    properties:
+      uaa:
+        url: &uaa-url "https://((web_ip)):8443"
+        port: -1
+        scim:
+          users:
+          - name: admin
+            password: ((uaa_users_admin))
+            groups:
+            - scim.write
+            - scim.read
+            - bosh.admin
+            - credhub.read
+            - credhub.write
+        admin: {client_secret: ((uaa_admin))}
+        login: {client_secret: ((uaa_login))}
+        zones: {internal: {hostnames: []}}
+        sslCertificate: ((atc_tls.certificate))
+        sslPrivateKey: ((atc_tls.private_key))
+        jwt:
+          revocable: true
+          policy:
+            active_key_id: key-1
+            keys:
+              key-1:
+                signingKey: ((uaa_jwt.private_key))
+      uaadb:
+        #address: ((db_ip))
+        port: 5432
+        db_scheme: postgresql
+        databases:
+        - tag: uaa
+          name: &uaa_db uaa
+        roles: 
+        - tag: admin
+          name: *uaa_db
+          password: &uaa_db_passwd ((uaa_db_password))
+      encryption:
+        active_key_label: key-1
+        encryption_keys:
+        - label: key-1
+          passphrase: ((uaa_encryption_key))
+      login:
+        saml:
+          serviceProviderCertificate: ((atc_tls.certificate))
+          serviceProviderKey: ((atc_tls.private_key))
+          serviceProviderKeyPassword: ""
+
+# variables
+- type: replace
+  path: /variables?/name=uaa_db_password?
+  value:
+    name: uaa_db_password
+    type: password
+- type: replace
+  path: /variables?/name=uaa_users_admin?
+  value:
+    name: uaa_users_admin
+    type: password
+- type: replace
+  path: /variables?/name=concourse_to_credhub_secret?
+  value:
+    name: concourse_to_credhub_secret
+    type: password
+- type: replace
+  path: /variables?/name=uaa_admin?
+  value:
+    name: uaa_admin
+    type: password
+- type: replace
+  path: /variables?/name=uaa_login?
+  value:
+    name: uaa_login
+    type: password
+- type: replace
+  path: /variables?/name=uaa_jwt?
+  value:
+    name: uaa_jwt
+    type: rsa
+    options:
+      key_length: 4096
+- type: replace
+  path: /variables?/name=uaa_encryption_key?
+  value:
+    name: uaa_encryption_key
+    type: password


### PR DESCRIPTION
Concourse v4.0.0 is really a big version bump. There are a lot changes especially in team/authentication portion.

This PR is to add UAA job colocated with Web node and make UAA as the OAuth Provider for both `main` team and other teams if you want.

To test it through, please refer to below steps and make necessary changes to adapt to your env:

## Spin Up Concourse Cluster
```sh
bosh -e lite deploy -d concourse4 concourse.yml \
  -l ../versions.yml \
  --vars-store cluster-creds.yml \
  -o operations/static-web.yml \
  -o operations/tls-vars.yml \
  -o operations/tls.yml \
  -o operations/privileged-https.yml \
  -o operations/add-main-team-oauth-users.yml \
  -o operations/postgres-link.yml \
  -o operations/uaa.yml \
  -o operations/uaa-generic-oauth-provider.yml \
  -v web_ip=10.244.0.104 \
  -v external_url=https://10.244.0.104 \
  -v external_host=10.244.0.104 \
  -v network_name=default \
  -v web_vm_type=small \
  -v db_vm_type=small \
  -v db_persistent_disk_type=10GB \
  -v worker_vm_type=small \
  -v deployment_name=concourse4 \
  -v uaa_version="60" \
  -v uaa_sha1="a7c14357ae484e89e547f4f207fb8de36d2b0966" \
  -v main_team_oauth_users='["bright"]'
```

## Create UAA users
```sh
$ uaac target https://10.244.0.104:8443
$ bosh int cluster-creds.yml --path /uaa_admin
$ uaac token client get
$ uaac users
$ uaac user add bright --emails xzheng@company.io -p mysecret
```

> Note: admin user is `admin`

## Test the newly created UAA user
```
$ fly login -t concourse4 -c https://10.244.0.104 -k
logging in to team 'main'

navigate to the following URL in your browser:

  https://10.244.0.104/sky/login?redirect_uri=http://127.0.0.1:58545/auth/callback

or enter token manually:
target saved

# fly -t concourse4 sp -p ring -c somepipeline.yml
# fly -t concourse4 up -p ring
```

> Note: if un-pausing through the UI button but it doesn't work, re-login can help.

## Create team(s) with Generic OAuth enabled
```
$ fly -t concourse4 set-team -n team-uaa-oauth --oauth-user bright
Team Name: team-uaa-oauth

Users:
- oauth:bright

Groups:
- none

apply configuration? [yN]: y
team created
```

## Login to the newly created team to test
```
$ fly login -t concourse4 -n team-uaa-oauth -c https://10.244.0.104 -k
# fly -t concourse4 sp -p ring -c somepipeline.yml
# fly -t concourse4 up -p ring
```

From UI you should be able to see something like this:
<img width="316" alt="screen shot 2018-08-15 at 10 48 43 pm" src="https://user-images.githubusercontent.com/1422425/44156349-4c8fc30c-a0e2-11e8-863b-b54aef014369.png">


## Known Concourse Issue in V4.0.0

1. Issue: No certs found in oauth_ca_cert

```
server: Failed to open connector oauth: failed to open connector: failed to create connector oauth: no certs found in root CA file "/var/vcap/jobs/atc/config/oauth_ca_cert"
```

**Solution:**
- Copy the ATC CA cert: `bosh int cluster-creds.yml --path /atc_ca/ca | pbcopy`
- SSH into ATC node and import it to ATC: `cat > /var/vcap/jobs/atc/config/oauth_ca_cert`
- Start/restart ATC process: `monit start atc`

