### PR TITLE
Add storage-driver ops file

### DIFF
--- a/cluster/operations/storage-driver.yml
+++ b/cluster/operations/storage-driver.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /instance_groups/name=worker/jobs/name=baggageclaim/properties/driver?
-  value: ((storage-driver))
+  value: ((storage_driver))

--- a/cluster/operations/storage-driver.yml
+++ b/cluster/operations/storage-driver.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=baggageclaim/properties/driver?
+  value: ((storage-driver))


### PR DESCRIPTION
This ops file enables users to override the default storage driver used. A var declaration when deploying is required.

Authored-by: Trevor Yacovone tyacovone@pivotal.io