### PR TITLE
Parameterize azs in concourse manifest

### DIFF
--- a/cluster/concourse.yml
+++ b/cluster/concourse.yml
@@ -18,7 +18,7 @@ releases:
 instance_groups:
 - name: web
   instances: 1
-  azs: [z1]
+  azs: ((availability_zone))
   networks: [{name: ((network_name))}]
   stemcell: xenial
   vm_type: ((web_vm_type))
@@ -48,7 +48,7 @@ instance_groups:
 
 - name: db
   instances: 1
-  azs: [z1]
+  azs: ((availability_zone))
   networks: [{name: ((network_name))}]
   stemcell: xenial
   vm_type: ((db_vm_type))
@@ -66,7 +66,7 @@ instance_groups:
 
 - name: worker
   instances: 1
-  azs: [z1]
+  azs: ((availability_zone))
   networks: [{name: ((network_name))}]
   stemcell: xenial
   vm_type: ((worker_vm_type))


### PR DESCRIPTION
All instances should be bound to the same availability zone and this
zone should be explicitly declared by the individual deploying the given
Concourse instance.

Authored-by: Trevor Yacovone <tyacovone@pivotal.io>