### PR TITLE
Make untrusted-worker able to reap own containers

### DIFF
--- a/cluster/operations/untrusted-worker.yml
+++ b/cluster/operations/untrusted-worker.yml
@@ -13,8 +13,11 @@
       consumes: {baggageclaim: {from: untrusted-baggageclaim}}
       properties:
         tags: ((untrusted_worker_tags))
-        garden: {forward_address: "127.0.0.1:7777"}
-        baggageclaim: {forward_address: "127.0.0.1:7788"}
+        garden:
+          address: 127.0.0.1:7777
+          forward_address: 127.0.0.1:7777
+        baggageclaim:
+          forward_address: 127.0.0.1:7788
         tsa:
           worker_key: ((worker_key))
           registration_mode: forward
@@ -28,6 +31,7 @@
       name: garden
       properties:
         garden:
+          forward_address: 127.0.0.1:7777
           listen_network: tcp
           listen_address: 127.0.0.1:7777
           deny_networks: ((untrusted_worker_deny_networks))


### PR DESCRIPTION
Referencing 7f268e3523123ec521953d59d85ccaf10f95f378

It looks like the untrusted-worker ops-file has gotten out of sync with
what's in cluster/external-worker.yml, and needs to set garden addresses
to be able to reap its own containers

Signed-off-by: Michelle He <mhe@pivotal.io>