### PR TITLE
use correct variable name for external_url

### DIFF
--- a/cluster/operations/tls-vars.yml
+++ b/cluster/operations/tls-vars.yml
@@ -14,5 +14,5 @@
     type: certificate
     options:
       ca: atc_ca
-      common_name: ((external_host))
-      alternative_names: [((external_host))]
+      common_name: ((external_url))
+      alternative_names: [((external_url))]


### PR DESCRIPTION
The rest of concourse-bosh-deployment uses `external_url` for this variable. 