### PR TITLE
Fix virtualbox stemcell for lite deployment

### DIFF
--- a/lite/infrastructures/virtualbox.yml
+++ b/lite/infrastructures/virtualbox.yml
@@ -10,8 +10,8 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: https://bosh.io/d/github.com/cppforlife/bosh-virtualbox-cpi-release?v=((virtualbox_cpi_version))
-    sha1: ((virtualbox_cpi_sha1))
+    url: https://bosh.io/d/stemcells/bosh-vsphere-esxi-ubuntu-xenial-go_agent?v=97.15
+    sha1: f3fa12c62892de8df5d404a6fb0875a3fb340569
 
 # Configure sizes
 - type: replace


### PR DESCRIPTION
This appears to have been an error in the changes to update the images from trusty to xenial in concourse/concourse-bosh-deployment#71

The lite deployment works as expected with these changes to correct the stemcell URL and SHA.