### PR TITLE
Fix consumes from for uaa-db

### DIFF
--- a/cluster/operations/uaa.yml
+++ b/cluster/operations/uaa.yml
@@ -24,7 +24,7 @@
   value:
     name: uaa
     release: uaa
-    consumes: {database: {from: db}}
+    consumes: {database: {from: postgres}}
     properties:
       uaa:
         url: &uaa-url "https://((web_ip)):8443"


### PR DESCRIPTION
`cluster/operations/uaa.yml` doesn't work because bosh can't find the link.  The link name for uaa-db seems wrong. 

cc: @brightzheng100  any thoughts?