### PR TITLE
ops files for valid x-frame-options settings

### DIFF
--- a/cluster/operations/x-frame-options-allow-from.yml
+++ b/cluster/operations/x-frame-options-allow-from.yml
@@ -1,0 +1,21 @@
+#
+#  This operations file will configure atc to include this HTTP header:
+#
+#      X-Frame-Options: allow-from https://example.com/
+#
+#  You can read more about this header and how it might help prevent
+#  clickjacking attacks [here][1].
+#
+#    [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+#
+#  The following URI parameter is required:
+#
+#      x_frame_options_allow_from: <uri>
+#
+#  It is mutually-exclusive with the other two x-frame-options*.yml
+#  operations files.
+#
+---
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/x_frame_options?
+  value: "allow ((x_frame_options_allow_from))"

--- a/cluster/operations/x-frame-options-deny.yml
+++ b/cluster/operations/x-frame-options-deny.yml
@@ -1,0 +1,18 @@
+#
+#  This operations file will configure atc to include this HTTP header:
+#
+#      X-Frame-Options: deny
+#
+#  You can read more about this header and how it might help prevent
+#  clickjacking attacks [here][1].
+#
+#    [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+#
+#  There are no configurable parameters associated with this
+#  operations file, and it is mutually-exclusive with the other two
+#  x-frame-options*.yml operations files.
+#
+---
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/x_frame_options?
+  value: "deny"

--- a/cluster/operations/x-frame-options-sameorigin.yml
+++ b/cluster/operations/x-frame-options-sameorigin.yml
@@ -1,0 +1,18 @@
+#
+#  This operations file will configure atc to include this HTTP header:
+#
+#      X-Frame-Options: sameorigin
+#
+#  You can read more about this header and how it might help prevent
+#  clickjacking attacks [here][1].
+#
+#    [1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+#
+#  There are no configurable parameters associated with this
+#  operations file, and it is mutually-exclusive with the other two
+#  x-frame-options*.yml operations files.
+#
+---
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/x_frame_options?
+  value: "sameorigin"


### PR DESCRIPTION
These mutually-exclusive ops files configure x-frame-options to help
prevent clickjacking attacks.