### PR TITLE
Re-ordered anchor declaration and usage in UAA ops file

### DIFF
--- a/cluster/operations/uaa.yml
+++ b/cluster/operations/uaa.yml
@@ -7,17 +7,6 @@
     sha1: ((uaa_sha1))
     version: ((uaa_version))
 
-# update postgres job to have uaa database
-- type: replace
-  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/databases/-
-  value:
-    name: *uaa_db
-- type: replace
-  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
-  value: 
-    name: *uaa_db
-    password: *uaa_db_passwd
-
 # add UAA job to web instance group
 - type: replace
   path: /instance_groups/name=web/jobs/-
@@ -72,6 +61,17 @@
           serviceProviderCertificate: ((atc_tls.certificate))
           serviceProviderKey: ((atc_tls.private_key))
           serviceProviderKeyPassword: ""
+
+# update postgres job to have uaa database
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/databases/-
+  value:
+    name: *uaa_db
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
+  value: 
+    name: *uaa_db
+    password: *uaa_db_passwd
 
 # variables
 - type: replace


### PR DESCRIPTION
If using a BOSH CLI later than v3.0.1 (e.g. we have tested on 4.x and 5.2.x), the UAA ops file cannot be deserialized because the `uaa_db` anchor is used before it is declared. This results in the following error message when attempting to add it to a deployment:

```
invalid argument for flag `-o, --ops-file' (expected []cmd.OpsFileArg): Deserializing ops file 'cluster/operations/uaa.yml': yaml: unknown anchor 'uaa_db' referenced
```

This change simply moves things around so the anchor is first declared before it is used.

