### PR TITLE
Don't assume the use of static_web.yml

### DIFF
--- a/cluster/operations/uaa-generic-oauth-provider.yml
+++ b/cluster/operations/uaa-generic-oauth-provider.yml
@@ -12,21 +12,21 @@
     authorized-grant-types: "authorization_code,refresh_token"
     access-token-validity: 3600
     refresh-token-validity: 7200
-    redirect-uri: https://((web_ip))/sky/issuer/callback
+    redirect-uri: "((external_url))/sky/issuer/callback"
 
 # integrate ATC by adding generic_oauth part
 - type: replace
   path: /instance_groups/name=web/jobs/name=atc/properties/generic_oauth?
   value:
-    auth_url: "https://((web_ip)):8443/oauth/authorize"
+    auth_url: "((external_url)):8443/oauth/authorize"
     ca_cert: ((atc_ca))
     client_id: concourse_generic_oauth_client
     client_secret: ((concourse_generic_oauth_client_secret))
     display_name: "UAA OAuth Provider"
     groups_key: []
     scopes: []
-    token_url: "https://((web_ip)):8443/oauth/token"
-    userinfo_url: "https://((web_ip)):8443/userinfo"
+    token_url: "((external_url)):8443/oauth/token"
+    userinfo_url: "((external_url)):8443/userinfo"
 
 # variables
 - type: replace

--- a/cluster/operations/uaa.yml
+++ b/cluster/operations/uaa.yml
@@ -14,7 +14,7 @@
     name: *uaa_db
 - type: replace
   path: /instance_groups/name=db/jobs/name=postgres/properties/databases/roles/-
-  value: 
+  value:
     name: *uaa_db
     password: *uaa_db_passwd
 
@@ -27,7 +27,7 @@
     consumes: {database: {from: db}}
     properties:
       uaa:
-        url: &uaa-url "https://((web_ip)):8443"
+        url: &uaa-url "((external_url)):8443"
         port: -1
         scim:
           users:
@@ -58,7 +58,7 @@
         databases:
         - tag: uaa
           name: &uaa_db uaa
-        roles: 
+        roles:
         - tag: admin
           name: *uaa_db
           password: &uaa_db_passwd ((uaa_db_password))


### PR DESCRIPTION
The `web_ip` variable is typically only defined when using `static_web.yml`, which assumes a single web instance.

Most deployments will have >1 web instances, so this file and variable will not be defined.  Use `external_url` instead of `web_ip` to allow for an arbitrary number of web instances behind the same load balancer.