### PR TITLE
Get rid of common_name from tls-vars

### DIFF
--- a/cluster/operations/tls-vars.yml
+++ b/cluster/operations/tls-vars.yml
@@ -14,5 +14,5 @@
     type: certificate
     options:
       ca: atc_ca
-      common_name: ((external_host))
       alternative_names: [((external_host))]
+      organization: atcOrg


### PR DESCRIPTION
It is outdated and is not as flexible. SAN should be enough.