### PR TITLE
add LDAP Integration

### DIFF
--- a/cluster/operations/ldap.yml
+++ b/cluster/operations/ldap.yml
@@ -1,0 +1,45 @@
+# add LDAP integretion to ATC job
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/ldap_auth?
+  value:
+    host: ((ldap_host))
+    bind_dn: ((ldap_bind_dn))
+    bind_pw: ((ldap_bind_pw))
+
+    # Required if LDAP host does not use TLS. Default: false
+    insecure_no_ssl: ((ldap_insecure_no_ssl))
+    # Skip certificate verification. Default: false
+    insecure_skip_verify: ((ldap_insecure_skip_verify))
+    # The CA certificate for the LDAP auth provider’s endpoints.
+    ca_cert: ((ldap_ca_cert))
+    # Start on insecure port, then negotiate TLS. Default: false
+    start_tls: ((ldap_start_tls))
+
+    # BaseDN to start the search from. e.g. "ou=people,dc=mycompany,dc=com"
+    user_search_base_dn: ((ldap_user_search_base_dn))
+    # Optional filter to apply when searching the directory. e.g. "(objectClass=person)"
+    user_search_filter: ((ldap_user_search_filter))
+    # Attribute to match against the inputted username. 
+    # This will be translated and combined with the other filter as ‘(=)‘.
+    user_search_username: ((ldap_user_search_username))
+    # A mapping of attributes on the user entry to claims. Defaults to ‘uid’ if empty.
+    user_search_id_attr: ((ldap_user_search_id_attr))
+    # A mapping of attributes on the user entry to claims.
+    user_search_name_attr: ((ldap_user_search_name_attr))
+    # A mapping of attributes on the user entry to claims. Defaults to ‘mail’ if empty.
+    user_search_email_attr: ((ldap_user_search_email_attr))
+    # Can either be ‘sub’ - search the whole sub tree or ‘one’ - only search one level. Defaults to ‘sub’ if empty.
+    user_search_scope: ((ldap_user_search_scope))
+
+    # BaseDN to start the search from. e.g. "ou=groups,dc=mycompany,dc=com"
+    group_search_base_dn: ((ldap_group_search_base_dn))
+    # Optional filter to apply when searching the directory. e.g. "(objectClass=posixGroup)"
+    group_search_filter: ((ldap_group_search_filter))
+    # Adds an additional requirement to the filter that an attribute in the group match the user’s attribute value.
+    # The exact filter being added is (=)
+    group_search_group_attr: ((ldap_group_search_group_attr))
+    group_search_user_attr: ((ldap_group_search_user_attr))
+    # The attribute of the group that represents its name, e.g. "cn"
+    group_search_name_attr: ((ldap_group_search_name_attr))
+    # Can either be ‘sub’ - search the whole sub tree or ‘one’ - only search one level. Defaults to ‘sub’ if empty.
+    group_search_scope: ((ldap_group_search_scope))


### PR DESCRIPTION
# LDAP Integration

## Setup Testing LDAP Server, like OpenLDAP (if required)

For a quick but complete setup of OpenLDAP, please refer to my blog [here](https://bright-zheng.blogspot.com/2018/10/how-to-series-how-to-quickly-setup.html)

Below assumes that you have set up LDAP Server with exact users, groups data and exposed as "ldap://192.168.50.1:10389".

## Spin Up Cluster

```sh
$ bosh -e lite deploy  --no-redact -d concourse4 concourse.yml \
  -l ../versions.yml \
  --vars-store cluster-creds.yml \
  -o operations/static-web.yml \
  -o operations/tls-vars.yml \
  -o operations/tls.yml \
  -o operations/privileged-https.yml \
  -o operations/add-local-users.yml \
  -o operations/ldap.yml \
  -v web_ip=10.244.0.104 \
  -v external_url=https://10.244.0.104 \
  -v external_host=10.244.0.104 \
  -v network_name=default \
  -v web_vm_type=small \
  -v db_vm_type=small \
  -v db_persistent_disk_type=10GB \
  -v worker_vm_type=small \
  -v deployment_name=concourse4 \
  -v main_team_local_users='["bright"]' \
  -v add_local_users='["bright:CHANGEME"]' \
  \
  -v ldap_host="192.168.50.1:10389" \
  -v ldap_bind_dn="cn=admin,dc=bright,dc=com" \
  -v ldap_bind_pw="secret" \
  -v ldap_insecure_no_ssl="true" \
  -v ldap_insecure_skip_verify="true" \
  -v ldap_ca_cert=" " \
  -v ldap_start_tls="false" \
  -v ldap_user_search_base_dn="ou=people,dc=bright,dc=com" \
  -v ldap_user_search_filter="(objectClass=person)" \
  -v ldap_user_search_username="cn" \
  -v ldap_user_search_id_attr="DN" \
  -v ldap_user_search_name_attr="cn" \
  -v ldap_user_search_email_attr="mail" \
  -v ldap_user_search_scope=" " \
  -v ldap_group_search_base_dn="ou=groups,dc=bright,dc=com" \
  -v ldap_group_search_filter="(objectClass=groupOfNames)" \
  -v ldap_group_search_group_attr="member" \
  -v ldap_group_search_user_attr="DN" \
  -v ldap_group_search_name_attr="cn" \
  -v ldap_group_search_scope=" "
```

> Note: tune accordingly to adapt to your env.


## Login to `main` Team

```
$ fly login -t concourse4 -c https://10.244.0.104 -k -u bright -p CHANGEME
$ fly -t concourse4 teams -d
name  users         groups
main  local:bright  none
```


## Create New Team(s)

Create different teams with `--ldap-user` and/or `--ldap-group`:

```
$ fly -t concourse4 set-team -n ldap-user --ldap-user=admin1 --non-interactive && \
  fly -t concourse4 set-team -n ldap-group --ldap-group=admins --non-interactive && \
  fly -t concourse4 set-team -n ldap-user-and-both --ldap-user=admin1 --ldap-group=admins --non-interactive

$ fly -t concourse4 teams -d
name                users         groups
ldap-group          none          ldap:admins
ldap-user           ldap:admin1   none
ldap-user-and-both  ldap:admin1   ldap:admins
main                local:bright  none
```


## SIT

Overall conclusions:

| User  | Which team to log into  | Teams can be viewed  | Operations eababled?  |
|---|---|---|---|
| admin1  | ldap-user  | all 3 teams  | Yes |
| admin1  | ldap-group  | all 3 teams  | Yes  |
| admin2  | ldap-group  | ldap-group and ldap-user-and-both only  | Yes  |
| admin1  | ldap-user-and-both  | all 3 teams  | Yes  |
| admin2  | ldap-user-and-both  | ldap-group and ldap-user-and-both only  | Yes  |

**TL;DR -- you may simply ignore the rest as it really works as expected :)**

Do the necessary preparation:

```
$ wget https://raw.githubusercontent.com/brightzheng100/concourse-demo/master/pipeline-ring.yml
```

> Note: better use Chrome Incognito window to perform each of below login steps to avoid potential token/session pollution.

### Login To Team `ldap-user` And Test It Out

Login using the test account: `admin1/secret`.

```
$ fly -t concourse4 login -n ldap-user -k
$ fly -t concourse4 teams -d
name                users        groups
ldap-group          none         ldap:admins
ldap-user           ldap:admin1  none
ldap-user-and-both  ldap:admin1  ldap:admins
```

Test:

```
$ fly -t concourse4 sp -p pipeline-ring -c pipeline-ring.yml && \
  fly -t concourse4 up -p pipeline-ring && \
  fly -t concourse4 trigger-job -j pipeline-ring/job-ring -w && \
  fly -t concourse4 dp -p pipeline-ring -n

started pipeline-ring/job-ring #1

initializing
...
running sh -exc date
echo "I love Concourse!"
+ date
Thu Oct 18 05:39:34 UTC 2018
+ echo 'I love Concourse!'
I love Concourse!
succeeded
...
```

**Conclusion:**

1. As `admin1` is explicitly specified in `ldap-user` and `ldap-user-and-both` and also belongs to group `admins`, so it displays all 3 teams as its `teams`;
2. User `admin1` can do the expected operations.


### Login To Team `ldap-group` And Test It Out

Login using both test accounts: `admin1/secret` and `admin2/secret`.

#### Login as `admin1/secret`

```
$ fly -t concourse4 login -n ldap-group -k
$ fly -t concourse4 teams -d
name                users        groups
ldap-group          none         ldap:admins
ldap-user           ldap:admin1  none
ldap-user-and-both  ldap:admin1  ldap:admins
```

**Test:**

```
$ fly -t concourse4 sp -p pipeline-ring -c pipeline-ring.yml && \
  fly -t concourse4 up -p pipeline-ring && \
  fly -t concourse4 trigger-job -j pipeline-ring/job-ring -w && \
  fly -t concourse4 dp -p pipeline-ring -n

started pipeline-ring/job-ring #1

initializing
...
running sh -exc date
echo "I love Concourse!"
+ date
Thu Oct 18 05:39:34 UTC 2018
+ echo 'I love Concourse!'
I love Concourse!
succeeded
```

**Conclusion:**

1. As `admin1` is explicitly specified in teams `ldap-user` and `ldap-user-and-both` and also belongs to group `admins`, so it displays all 3 teams as its `teams`;
2. User `admin1` can do the expected operations.

#### Login as `admin2/secret`

```
$ fly -t concourse4 login -n ldap-group -k
$ fly -t concourse4 teams -d
name                users        groups
ldap-group          none         ldap:admins
ldap-user-and-both  ldap:admin1  ldap:admins
```

**Test:**

```
$ fly -t concourse4 sp -p pipeline-ring -c pipeline-ring.yml && \
  fly -t concourse4 up -p pipeline-ring && \
  fly -t concourse4 trigger-job -j pipeline-ring/job-ring -w && \
  fly -t concourse4 dp -p pipeline-ring -n

started pipeline-ring/job-ring #1

initializing
...
running sh -exc date
echo "I love Concourse!"
+ date
Thu Oct 18 05:39:34 UTC 2018
+ echo 'I love Concourse!'
I love Concourse!
succeeded
```

**Conclusion:**

1. As `admin2` belongs to group `admins`, so it displays 2 related teams as its `teams`;
2. User `admin2` can do the expected operations.


### Login To Team `ldap-user-and-both` And Test It Out

Login using both test accounts: `admin1/secret` and `admin2/secret`.

#### Login as `admin1/secret`

```
$ fly -t concourse4 login -n ldap-user-and-both -k
$ fly -t concourse4 teams -d
name                users        groups
ldap-group          none         ldap:admins
ldap-user           ldap:admin1  none
ldap-user-and-both  ldap:admin1  ldap:admins
```

Test:

```
$ fly -t concourse4 sp -p pipeline-ring -c pipeline-ring.yml && \
  fly -t concourse4 up -p pipeline-ring && \
  fly -t concourse4 trigger-job -j pipeline-ring/job-ring -w && \
  fly -t concourse4 dp -p pipeline-ring -n

started pipeline-ring/job-ring #1

initializing
...
running sh -exc date
echo "I love Concourse!"
+ date
Thu Oct 18 05:39:34 UTC 2018
+ echo 'I love Concourse!'
I love Concourse!
succeeded
```

**Conclusion:**

1. As `admin1` is explicitly specified in teams `ldap-user`, `ldap-user-and-both` and also belongs to group `admins`, so it displays all 3 teams as its `teams`;
2. User `admin1` can do the expected operations.


#### Login as `admin2/secret`

```
$ fly -t concourse4 login -n ldap-group -k
$ fly -t concourse4 teams -d
name                users        groups
ldap-group          none         ldap:admins
ldap-user-and-both  ldap:admin1  ldap:admins
```

**Test:**

```
$ fly -t concourse4 sp -p pipeline-ring -c pipeline-ring.yml && \
  fly -t concourse4 up -p pipeline-ring && \
  fly -t concourse4 trigger-job -j pipeline-ring/job-ring -w && \
  fly -t concourse4 dp -p pipeline-ring -n

started pipeline-ring/job-ring #1

initializing
...
running sh -exc date
echo "I love Concourse!"
+ date
Thu Oct 18 05:39:34 UTC 2018
+ echo 'I love Concourse!'
I love Concourse!
succeeded
```

**Conclusion:**

1. As `admin2` belongs to group `admins`, so it displays 2 related teams as its `teams`;
2. User `admin2` can do the expected operations.


All done!