### PR TITLE
Removes log_level: debug / adds ops-files for enabling debug

### DIFF
--- a/cluster/concourse.yml
+++ b/cluster/concourse.yml
@@ -26,7 +26,6 @@ instance_groups:
   - release: concourse
     name: atc
     properties:
-      log_level: debug
 
       token_signing_key: ((token_signing_key))
 
@@ -41,7 +40,6 @@ instance_groups:
   - release: concourse
     name: tsa
     properties:
-      log_level: debug
       host_key: ((tsa_host_key))
       token_signing_key: ((token_signing_key))
       authorized_keys: [((worker_key.public_key))]
@@ -80,7 +78,6 @@ instance_groups:
 
   - release: concourse
     name: baggageclaim
-    properties: {log_level: debug}
     provides: {baggageclaim: {as: worker-baggageclaim}}
 
   - release: garden-runc

--- a/cluster/external-worker.yml
+++ b/cluster/external-worker.yml
@@ -43,7 +43,6 @@ instance_groups:
     release: concourse
     provides: {baggageclaim: {as: worker-baggageclaim}}
     properties:
-      log_level: debug
       bind_ip: 127.0.0.1
   - name: garden
     release: garden-runc

--- a/cluster/operations/debug-concourse.yml
+++ b/cluster/operations/debug-concourse.yml
@@ -1,0 +1,12 @@
+---
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/log_level?
+  value: debug
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=tsa/properties/log_level?
+  value: debug
+
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=baggageclaim/properties?/log_level
+  value: debug

--- a/cluster/operations/debug-external-worker.yml
+++ b/cluster/operations/debug-external-worker.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=baggageclaim/properties/log_level?
+  value: debug

--- a/cluster/operations/debug-tagged-worker.yml
+++ b/cluster/operations/debug-tagged-worker.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=worker-((worker_tag))/jobs/name=baggageclaim/properties?/log_level
+  value: debug

--- a/cluster/operations/debug-untrusted-worker.yml
+++ b/cluster/operations/debug-untrusted-worker.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=untrusted-worker/jobs/name=baggageclaim/properties/log_level?
+  value: debug

--- a/cluster/operations/tagged-worker.yml
+++ b/cluster/operations/tagged-worker.yml
@@ -18,7 +18,6 @@
     - release: concourse
       name: baggageclaim
       provides: {baggageclaim: {as: baggageclaim-((worker_tag))}}
-      properties: {log_level: debug}
 
     - release: garden-runc
       name: garden

--- a/cluster/operations/untrusted-worker.yml
+++ b/cluster/operations/untrusted-worker.yml
@@ -22,7 +22,6 @@
       name: baggageclaim
       provides: {baggageclaim: {as: untrusted-baggageclaim}}
       properties:
-        log_level: debug
         bind_ip: 127.0.0.1
     - release: garden-runc
       name: garden

--- a/lite/concourse.yml
+++ b/lite/concourse.yml
@@ -97,8 +97,6 @@ instance_groups:
 
   - release: concourse
     name: baggageclaim
-    properties:
-      log_level: debug
 
   - release: garden-runc
     name: garden

--- a/lite/operations/debug.yml
+++ b/lite/operations/debug.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=concourse/jobs/name=baggageclaim/properties?/log_level
+  value: debug


### PR DESCRIPTION
Removes `log_level: debug`, ops-files have been created for operators who which to enable debugging.  However by default this should not be enabled.

Thanks