### PR TITLE
Update bosh-openstack-cpi-release github org

### DIFF
--- a/lite/infrastructures/openstack.yml
+++ b/lite/infrastructures/openstack.yml
@@ -4,8 +4,8 @@
   value:
     name: bosh-openstack-cpi
     version: 32
-    url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-openstack-cpi-release?v=32
-    sha1: ed97641c755f455f2494fe1d7016b9fd1c3ec1e8
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-openstack-cpi-release?v=32
+    sha1: c8c35cba7ed1281a5c740e6b5f8c4c5472d7e843
 
 - type: replace
   path: /resource_pools/name=vms/stemcell?


### PR DESCRIPTION
The bosh-openstack-cpi-release github repo moved from incubator to regular cloudfoundry org. It has new SHA1 checksum, but release is the same.

Co-authored-by: Florian Nachtigall <florian.nachtigall@sap.com>