### PR TITLE
Single vm

### DIFF
--- a/cluster/operations/single-vm.yml
+++ b/cluster/operations/single-vm.yml
@@ -1,0 +1,51 @@
+- type: remove
+  path: /instance_groups/name=db
+- type: remove
+  path: /instance_groups/name=worker
+- type: replace
+  path: /instance_groups/name=web/persistent_disk_type?
+  value: ((db_persistent_disk_type))
+#- type: replace
+#  path: /instance_groups/name=web/jobs/name=atc/properties/postgresql/host?
+#  value: 127.0.0.1
+#- type: replace
+#  path: /instance_groups/name=web/jobs/name=atc/properties/postgresql/sslmode?
+#  value: disable
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    release: postgres
+    name: postgres
+    properties:
+      databases:
+        port: 5432
+        databases:
+        - name: atc
+        roles:
+        - name: concourse
+          password: ((postgres_password))
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    release: concourse
+    name: worker
+    consumes: {baggageclaim: {from: worker-baggageclaim}}
+    properties:
+      drain_timeout: 10m
+      tsa: {worker_key: ((worker_key))}
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    release: concourse
+    name: baggageclaim
+    properties: {log_level: debug}
+    provides: {baggageclaim: {as: worker-baggageclaim}}
+- type: replace
+  path: /instance_groups/name=web/jobs/-
+  value:
+    release: garden-runc
+    name: garden
+    properties:
+      garden:
+        listen_network: tcp
+        listen_address: 0.0.0.0:7777

--- a/cluster/operations/single-vm.yml
+++ b/cluster/operations/single-vm.yml
@@ -5,12 +5,6 @@
 - type: replace
   path: /instance_groups/name=web/persistent_disk_type?
   value: ((db_persistent_disk_type))
-#- type: replace
-#  path: /instance_groups/name=web/jobs/name=atc/properties/postgresql/host?
-#  value: 127.0.0.1
-#- type: replace
-#  path: /instance_groups/name=web/jobs/name=atc/properties/postgresql/sslmode?
-#  value: disable
 - type: replace
   path: /instance_groups/name=web/jobs/-
   value:

--- a/cluster/operations/web-ephemeral-disk.yml
+++ b/cluster/operations/web-ephemeral-disk.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/vm_extensions?/-
+  value: ((web_ephemeral_disk))


### PR DESCRIPTION
Changes in this PR include an ops file (`single-vm.yml`) that collapses the 3 instance-groups of the cluster deployment into 1. The purpose is to enable users to deploy a single-vm Concourse with an existing Bosh Director, primarily targeting BBL users that don't want a large Concourse deployment

To facilitate reuse of most existing ops files, the remaining instance-group will be called `web`.

On the other hand, since all jobs now run in that same instance-group, this single-vm must be sized accordingly and must incorporate the `db_persistent_disk`.
Additionally, for many pipelines that manage large artifacts (i.e: `pcf-pipelines`) you need a larger ephemeral disk. For this purpose I have included a second ops-file (`web-ephemeral-disk.yml`).

