### PR TITLE
Add worker rebalancing configuration

### DIFF
--- a/cluster/operations/worker-rebalancing.yml
+++ b/cluster/operations/worker-rebalancing.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=worker/properties/worker_gateway/rebalance_interval?
+  value: ((worker_rebalance_interval))


### PR DESCRIPTION
Hey,

This PR is intended to allow a user to configure the worker rebalance interval property introduced in concourse/concourse#2312.

```yaml
  worker_gateway.rebalance_interval:
    env: CONCOURSE_REBALANCE_INTERVAL
    description: |
      The interval on which the worker will connect to a new SSH gateway and
      drain the old connection. This has the effect of rebalancing the
      forwarded workers across the SSH gateways over time.
      If not specified, the worker will not rebalance over time, and instead
      stick with whichever SSH gateway it initially connected to.
```

> see in [concourse-bosh-release#jobs/worker/spec](https://github.com/concourse/concourse-bosh-release/blob/553e04b80f7e33a6f1a5cc2bff3d4101ee1aeb56/jobs/worker/spec#L119-L127)

Please let me know if there's anything I'm missing!

Thanks


