### PR TITLE
worker_gateway.authorized_keys is no longer a list

### DIFF
--- a/cluster/concourse.yml
+++ b/cluster/concourse.yml
@@ -41,7 +41,8 @@ instance_groups:
 
       worker_gateway:
         host_key: ((tsa_host_key))
-        authorized_keys: [((worker_key.public_key))]
+        authorized_keys: |
+          ((worker_key.public_key))
 
 - name: db
   instances: 1


### PR DESCRIPTION
When deploying only one worker, the YAML array notation ends up being swallowed up by the templating on the BOSH job, but it should be a string now.

cc @fmartini

Co-Authored-By: Felisia Martini <fmartini@pivotal.io>