### PR TITLE
3.13.x: ops file to prevent accessing web UI from iframe

### DIFF
--- a/cluster/operations/prevent-iframes.yml
+++ b/cluster/operations/prevent-iframes.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=atc/properties/x_frame_options?
+  value: deny


### PR DESCRIPTION
By default the web server will leave that header blank, and this might be a more suitable default.