### PR TITLE
Fix ldap.yml path:

### DIFF
--- a/cluster/operations/ldap.yml
+++ b/cluster/operations/ldap.yml
@@ -1,6 +1,6 @@
 # add LDAP integretion to ATC job
 - type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/ldap_auth?
+  path: /instance_groups/name=web/jobs/name=web/properties/ldap_auth?
   value:
     host: ((ldap_host))
     bind_dn: ((ldap_bind_dn))


### PR DESCRIPTION
The current path is incorrect, it should be  path: /instance_groups/name=web/jobs/name=web/properties/ldap_auth? . The current path must be the old path from previous versions. I am currently using v5 and above.