### PR TITLE
fix #154

### DIFF
--- a/cluster/operations/add-main-team-cf-orgs.yml
+++ b/cluster/operations/add-main-team-cf-orgs.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/cf/orgs?
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/cf/orgs?
   value: ((main_team_cf_orgs))

--- a/cluster/operations/add-main-team-cf-spaces.yml
+++ b/cluster/operations/add-main-team-cf-spaces.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/cf/spaces?
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/cf/spaces?
   value: ((main_team_cf_spaces))

--- a/cluster/operations/add-main-team-cf-users.yml
+++ b/cluster/operations/add-main-team-cf-users.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/cf/users?
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/cf/users?
   value: ((main_team_cf_users))

--- a/cluster/operations/add-main-team-oidc-groups.yml
+++ b/cluster/operations/add-main-team-oidc-groups.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/oidc/groups
+  value: ((main_team.oidc.groups))

--- a/cluster/operations/add-main-team-oidc-users.yl
+++ b/cluster/operations/add-main-team-oidc-users.yl
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/oidc/users
+  value: ((main_team.oidc.users))

--- a/cluster/operations/add-main-team-oidc-users.yl
+++ b/cluster/operations/add-main-team-oidc-users.yl
@@ -1,3 +1,0 @@
-- type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/oidc/users
-  value: ((main_team.oidc.users))

--- a/cluster/operations/add-main-team-oidc-users.yml
+++ b/cluster/operations/add-main-team-oidc-users.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/oidc/users
+  value: ((main_team.oidc.users))

--- a/cluster/operations/generic-oidc.yml
+++ b/cluster/operations/generic-oidc.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/generic_oidc?
+  path: /instance_groups/name=web/jobs/name=web/properties/generic_oidc?
   value:
     client_id: ((oidc.client_username))
     client_secret: ((oidc.client_password))
@@ -7,11 +7,3 @@
     scopes: ((oidc.scopes))
     groups_key: ((oidc.groups_key))
     display_name: ((oidc.display_name))
-
-- type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/oidc/users
-  value: ((main_team.oidc.users))
-
-- type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/main_team?/auth/oidc/groups
-  value: ((main_team.oidc.groups))

--- a/cluster/operations/generic-oidc.yml
+++ b/cluster/operations/generic-oidc.yml
@@ -7,3 +7,4 @@
     scopes: ((oidc.scopes))
     groups_key: ((oidc.groups_key))
     display_name: ((oidc.display_name))
+    user_name_key: ((oidc.user_name_key))


### PR DESCRIPTION
fix #154 .

And separated `generic-oidc.yml`, because it is not a set to use oidc and to use the authentication of the main team.