### PR TITLE
Add certificate to path

### DIFF
--- a/cluster/operations/external-postgres-tls.yml
+++ b/cluster/operations/external-postgres-tls.yml
@@ -1,6 +1,6 @@
 # requires the external-postgres.yml op file
 - type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/ca_cert?
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/ca_cert?/certificate?
   value: ((postgres_ca_cert))
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/postgresql/sslmode?


### PR DESCRIPTION
This brings the `external-postgres-tls` opsfile in line with the changes made to Concourse bosh release > 5.0.  