### PR TITLE
Fix postgresql certificate path

### DIFF
--- a/cluster/operations/external-postgres-tls.yml
+++ b/cluster/operations/external-postgres-tls.yml
@@ -1,6 +1,6 @@
 # requires the external-postgres.yml op file
 - type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/ca_cert?
+  path: /instance_groups/name=web/jobs/name=web/properties/postgresql/ca_cert?/certificate
   value: ((postgres_ca_cert))
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/postgresql/sslmode?


### PR DESCRIPTION
https://github.com/concourse/concourse-bosh-release/blob/1b8953a55b20c5d377fc8ae8b4f2170c6ef49e0c/jobs/web/spec#L778-L782

The opsfile was missing the `certificate` part of the path.

cc @sophiewigmore @yaelharel