### PR TITLE
Add ops-file for gitlab concourse auth integration

### DIFF
--- a/cluster/operations/gitlab-auth.yml
+++ b/cluster/operations/gitlab-auth.yml
@@ -1,0 +1,21 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/gitlab_auth?/host?
+  value: ((gitlab_host))
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/gitlab/users
+  value:
+  value: ((main_team.gitlab_users))
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/gitlab/groups
+  value:
+  value: ((main_team.gitlab_groups))
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/gitlab_auth?/client_id?
+  value: ((gitlab_client_id))
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/gitlab_auth?/client_secret?
+  value: ((gitlab_client_secret))


### PR DESCRIPTION
This is a fix for #128 which adds an ops-file for gitlab integration similar to the existing one for github.