### PR TITLE
Correctly surround host by quotes

### DIFF
--- a/cluster/external-worker.yml
+++ b/cluster/external-worker.yml
@@ -25,7 +25,7 @@ instance_groups:
       log_level: debug
       tags: ((worker_tags))
       worker_gateway:
-        hosts: [((tsa_host)):2222]
+        hosts: ["((tsa_host)):2222"]
         host_public_key: ((tsa_host_key.public_key))
         worker_key: ((worker_key))
 


### PR DESCRIPTION
**Problem**

The use of ":" on line 28 breaks bosh interpolation, as the ":" character is interpreted as a key separator.

`yaml: line 27: found unexpected ':'`

**How to Reproduce:**

Run `bosh int external-worker.yml`

**Versions:**

Concourse-bosh-deployment: latest (5.2)
Bosh Int: version 3.0.1