### PR TITLE
add ldap groups to main team

### DIFF
--- a/cluster/operations/add-main-team-ldap-groups.yml
+++ b/cluster/operations/add-main-team-ldap-groups.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/ldap/groups
+  value: ((main_team.ldap.groups))


### PR DESCRIPTION
We authorize listed ldap groups to access to concourse main team.