### PR TITLE
Correct bpm checksum

### DIFF
--- a/versions.yml
+++ b/versions.yml
@@ -9,7 +9,7 @@
 concourse_version: '5.3.0'
 concourse_sha1: '97410a92b3c2385b728a7414ad34520491701d4e'
 bpm_version: '1.0.4'
-bpm_sha1: '41df19697d6a69d2552bc2c132928157fa91abe0'
+bpm_sha1: 'c2cceb2d1e271a2f7c5e7c563a7b26f919ebc17a'
 postgres_version: '37'
 postgres_sha1: '0bffec6b98df81219a18ec8da0e19721be799eed'
 windows_utilities_version: '0.11.0'


### PR DESCRIPTION
The SHA1 of the bpm release is incorrect, perhaps related to the recent URL change?

https://bosh.io/releases/github.com/cloudfoundry/bpm-release?version=1.0.4 says it's the value in this commit, and that value agrees with a check via `curl --location 'https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.0.4' | shasum`