### PR TITLE
allow credential manager properties customization

### DIFF
--- a/cluster/operations/credential-manager-enable-cache.yml
+++ b/cluster/operations/credential-manager-enable-cache.yml
@@ -1,0 +1,4 @@
+- type: replace
+  # Enable in-memory caching of secrets fetched from the credential manager.
+  path: /instance_groups/name=web/jobs/name=web/properties/secrets?/cache?/enabled?
+  value: true

--- a/cluster/operations/credential-manager-tuning.yml
+++ b/cluster/operations/credential-manager-tuning.yml
@@ -1,0 +1,19 @@
+- type: replace
+  # When credential manager is enabled, maximum duration for which to keep cached credentials. Default with concourse 5.3: 1m
+  path: /instance_groups/name=web/jobs/name=web/properties/secrets?/cache?/duration?
+  value: ((credential-manager.duration))
+
+- type: replace
+  # When credential manager is enabled, interval on which to purge expired cached credentials. Default with concourse 5.3: 10m
+  path: /instance_groups/name=web/jobs/name=web/properties/secrets?/cache?/purge_interval?
+  value: ((credential-manager.purge_interval))
+
+- type: replace
+  # When credential manager is enabled, the interval between secret retry retrieval attempts. Default with concourse 5.3: 10s
+  path: /instance_groups/name=web/jobs/name=web/properties/secrets?/cache?/retry_interval?
+  value: ((credential-manager.retry_interval))
+
+- type: replace
+  # When credential manager is enabled, the number of attempts secret will be retried to be fetched, in case a retryable error happens. Default with concourse 5.3: 5
+  path: /instance_groups/name=web/jobs/name=web/properties/secrets?/cache?/retry_attempts?
+  value: ((credential-manager.retry_attempts))

--- a/cluster/operations/vault-enable-cache.yml
+++ b/cluster/operations/vault-enable-cache.yml
@@ -1,3 +1,0 @@
-- type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/vault/cache?
-  value: true


### PR DESCRIPTION
we split into 2 operators
 - an operator just to enable credential cache (it's a replacement of old vault operator with new credential manager cache properties)
 - another to customize other credential cache properties

Signed-off-by: Olivier ORAND <olivier.orand@orange.com>