### PR TITLE
Differentiate vm_type for tagged worker and add new ops file for setting proxy for tagged worker

### DIFF
--- a/cluster/operations/http-proxy-tagged-worker.yml
+++ b/cluster/operations/http-proxy-tagged-worker.yml
@@ -1,0 +1,9 @@
+- type: replace
+  path: /instance_groups/name=worker-((worker_tag))/jobs/name=worker/properties/http_proxy_url?
+  value: ((http_proxy_url))
+- type: replace
+  path: /instance_groups/name=worker-((worker_tag))/jobs/name=worker/properties/https_proxy_url?
+  value: ((https_proxy_url))
+- type: replace
+  path: /instance_groups/name=worker-((worker_tag))/jobs/name=worker/properties/no_proxy?
+  value: ((no_proxy)) # --var no_proxy='["localhost", "127.0.0.1", "example.com", "domain.com:8080"]'

--- a/cluster/operations/tagged-worker.yml
+++ b/cluster/operations/tagged-worker.yml
@@ -3,7 +3,7 @@
   value:
     name: worker-((worker_tag))
     instances: 1
-    vm_type: ((worker_vm_type))
+    vm_type: ((tagged_worker_vm_type))
     stemcell: xenial
     networks: [{name: ((network_name))}]
     azs: [z1]


### PR DESCRIPTION
Two changes in this PR:

**1. Use a dedicated variable `tagged_worker_vm_type` for setting the tagged worker**

It's common to have different vm types for no-tag worker pool and tagged worker.

For example, we may use `xlarge` vm type for default shareable workers, while setting a `xlarge_disks` one for tagged worker for `BBR` purposes.

**2. Create a new ops file for setting the http(s) proxy for tagged worker**

The current `http-proxy.yml` can't support proxy setting for tagged worker.
So we need a new one for it.

As a result, if we're going to spin up a cluster with shareable worker pool and tagged worker, and (optionally) to set the http(s) proxy for it, we can do something like:

```
bosh deploy -d concourse cluster/concourse.yml \
  -l versions.yml \
  ...
  -o cluster/operations/http-proxy.yml \
  ...
  -o cluster/operations/tagged-worker.yml \
  -o cluster/operations/http-proxy-tagged-worker.yml \
  ...
  -v http_proxy_url=https://myproxy.com \
  -v https_proxy_url=https://myproxy.com \
  -v no_proxy='["localhost", "127.0.0.1", "example.com", "domain.com:8080"]'
  ...
  -v worker_tag=bbr \
  -v tagged_worker_vm_type=xlarge_disks \
  ...
```

> Note: the newly added `http-proxy-tagged-worker.yml` fully respects the variables defined in `http-proxy.yml` and no new variables are added.