### PR TITLE
add ops file to use limit-active-tasks strategy

### DIFF
--- a/cluster/operations/container-placement-strategy-limit-active-tasks.yml
+++ b/cluster/operations/container-placement-strategy-limit-active-tasks.yml
@@ -1,0 +1,7 @@
+---
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/container_placement_strategy?
+  value: "limit-active-tasks"
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/max_active_tasks_per_worker?
+  value: ((max-active-tasks-per-worker))


### PR DESCRIPTION
We want to use `limit-active-tasks` on our prod environment. This PR adds an ops file to enable `limit-active-tasks`.

Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>