### PR TITLE
add ops file to set metrics buffer size

### DIFF
--- a/cluster/operations/metrics-buffer-size.yml
+++ b/cluster/operations/metrics-buffer-size.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/metrics_buffer_size?
+  value: ((metrics_buffer_size))


### PR DESCRIPTION
Hey,

We're making the [`web.metrics_buffer_size`](https://bosh.io/jobs/web?source=github.com/concourse/concourse-bosh-release&version=5.5.1#p%3dmetrics_buffer_size) property configurable to that folks can leverage https://github.com/concourse/concourse/pull/3937.

We tried `bosh int`, with success.

Thanks!