### PR TITLE
Allow tweaking lidar intervals

### DIFF
--- a/cluster/operations/lidar-intervals.yml
+++ b/cluster/operations/lidar-intervals.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/lidar_checker_interval?
+  value: ((lidar_checker_interval))
+
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/lidar_scanner_interval?
+  value: ((lidar_scanner_interval))


### PR DESCRIPTION
Although we previously added the ability to enable `lidar`, it missed
the configuration of its intervals.