### PR TITLE
Changed instance groups update mechanism to serial

### DIFF
--- a/cluster/concourse.yml
+++ b/cluster/concourse.yml
@@ -93,6 +93,6 @@ stemcells:
 update:
   canaries: 1
   max_in_flight: 3
-  serial: false
+  serial: true
   canary_watch_time: 1000-60000
   update_watch_time: 1000-60000


### PR DESCRIPTION
Signed-off-by: Alexander Bakardzhiev <alexander.bakardzhiev@sap.com>

Related to https://github.com/concourse/concourse-bosh-release/issues/44
If the instance groups are updated in parallel, race conditions between the (instance group of) web nodes and (instance group of) worker nodes may happen, for example as with the case of long-running draining mentioned in the above issue. Making the instance groups update serial would avoid such race conditions. 
*Note that this change won't affect how the instances in the instance groups are updated (they can still be updated in parallel as "max_in_flight" is set to 3.
