### PR TITLE
Adding ops file to skip credhub tls verification

### DIFF
--- a/cluster/operations/credhub-tls-skip-verify.yml
+++ b/cluster/operations/credhub-tls-skip-verify.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/credhub/tls/insecure_skip_verify?
+  value: true


### PR DESCRIPTION
This is required for platform automation that uses an embedded task to interpolate values from credhub. If not using legit certs, one can use the ops files to skip tls verification