### PR TITLE
Add flags to disable per-volume metric reporting

### DIFF
--- a/cluster/operations/datadog.yml
+++ b/cluster/operations/datadog.yml
@@ -47,8 +47,8 @@
             - use_mount: yes
               tag_by_filesystem: true
               all_partitions: true
-              device_blacklist:
-              - /var/vcap/data/worker/work/volumes/*/**
+              mount_point_blacklist:
+              - ^\/var\/vcap\/data\/worker\/work\/volumes\/.*
               excluded_filesystems:
                 - tracefs
 

--- a/cluster/operations/datadog.yml
+++ b/cluster/operations/datadog.yml
@@ -34,6 +34,24 @@
         # time (whoever starts up last)
         unique_friendly_hostname: true
 
+        # by default, the agent will emit disk usage for every volume.
+        # this results in noisy, high-cardinality metrics that are also
+        # very expensive! these two config flags override the defaults,
+        # and disable per-volume reporting.
+        generate_disk_config: false
+        disk_yaml_config: |
+          ---
+          init_config:
+
+          instances:
+            - use_mount: yes
+              tag_by_filesystem: true
+              all_partitions: true
+              device_blacklist:
+              - /var/vcap/data/worker/work/volumes/*/**
+              excluded_filesystems:
+                - tracefs
+
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/datadog?
   value:

--- a/cluster/operations/datadog.yml
+++ b/cluster/operations/datadog.yml
@@ -49,8 +49,8 @@
               all_partitions: true
               mount_point_blacklist:
               - ^\/var\/vcap\/data\/worker\/work\/volumes\/.*
-              excluded_filesystems:
-                - tracefs
+              file_system_blacklist:
+              - tracefs
 
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/datadog?


### PR DESCRIPTION
By default, the Datadog agent's disk reporter wants to
  export metrics for every volume. Concourse workers have
  a LOT of volumes and we're not interested in this degree
  of cardinality.

Signed-off-by: Denise Yu <dyu@pivotal.io>

I know we normally try to be additive with changes to ops files, but I seriously don't believe that anyone wants this level of cardinality for disk usage. We're not concerned about disk usage on these volumes, only on the hosts.