### PR TITLE
auth: fixed oidc.

### DIFF
--- a/cluster/operations/add-main-team-oidc-groups.yml
+++ b/cluster/operations/add-main-team-oidc-groups.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/oidc/groups
-  value: ((main_team.oidc.groups))
+  value: ((main_team.auth.oidc.groups))

--- a/cluster/operations/add-main-team-oidc-users.yml
+++ b/cluster/operations/add-main-team-oidc-users.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/main_team?/auth/oidc/users
-  value: ((main_team.oidc.users))
+  value: ((main_team.auth.oidc.users))


### PR DESCRIPTION
the oidc ops files had a bad config, they were missing a key. this puts
the key in place so oidc works out of the box again.

See: https://discordapp.com/channels/219899946617274369/413770960089382922/639560920502108180

Signed-off-by: Mike Lloyd <mike@reboot3times.org>