### PR TITLE
Add ops-file for generating worker key

### DIFF
--- a/cluster/operations/add-worker-key-variable.yml
+++ b/cluster/operations/add-worker-key-variable.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /variables?/-
+  value:
+    name: worker_key
+    type: ssh


### PR DESCRIPTION
For use with the external-worker manifest. I'm writing docs for creating
an external worker and realized having an ops-file for operators to use
would be useful. Many operators take advantage of BOSH/Credhub
generating variables for you. They may appreciate having an ops-file
that does that for them and I'd like to reference it in our enterprise
docs.