### PR TITLE
Add ops file to allow for adding external worker keys

### DIFF
--- a/cluster/operations/add-external-worker-keys.yml
+++ b/cluster/operations/add-external-worker-keys.yml
@@ -1,0 +1,5 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/worker_gateway/authorized_keys
+  value: |
+    ((worker_key.public_key))
+    ((external_worker_authorized_keys))


### PR DESCRIPTION
Our team has to manually modify concourse.yml to add in the external_worker_authorized_keys. We thought adding this ops file may help others who do the same.

I did not see a way to append a value to a string, so in this PR, I just overwrite the string. Please let me know if there is a better way to do this.