### PR TITLE
opsfile to enable bosh release offline mode

### DIFF
--- a/cluster/operations/offline-releases.yml
+++ b/cluster/operations/offline-releases.yml
@@ -1,6 +1,9 @@
-# this remove all bosh.io references
+# This remove all bosh.io references
 # used to ensure that the bosh director does
 # not call out to the open Internet
+
+# Requires all bosh releases that will be used
+# to have been uploaded to the bosh director
 - type: remove
   path: /releases/name=concourse?/url
 - type: remove

--- a/cluster/operations/offline-releases.yml
+++ b/cluster/operations/offline-releases.yml
@@ -1,0 +1,31 @@
+# this remove all bosh.io references
+# used to ensure that the bosh director does
+# not call out to the open Internet
+- type: remove
+  path: /releases/name=concourse?/url
+- type: remove
+  path: /releases/name=bpm?/url
+- type: remove
+  path: /releases/name=postgres?/url
+- type: remove
+  path: /releases/name=uaa?/url
+- type: remove
+  path: /releases/name=credhub?/url
+- type: remove
+  path: /releases/name=bbr?/url
+- type: remove
+  path: /releases/name=windows-utilities?/url
+- type: remove
+  path: /releases/name=concourse?/sha1
+- type: remove
+  path: /releases/name=bpm?/sha1
+- type: remove
+  path: /releases/name=postgres?/sha1
+- type: remove
+  path: /releases/name=uaa?/sha1
+- type: remove
+  path: /releases/name=credhub?/sha1
+- type: remove
+  path: /releases/name=bbr?/sha1
+- type: remove
+  path: /releases/name=windows-utilities?/sha1


### PR DESCRIPTION
This ops-file disables the `url` and `sha1` attributes of the `releases` section of the bosh deployment manifest.
When using a bosh director that doesn't have access to the open Internet, we'd like to have a way of ensuring bosh releases are checked only on the bosh director.

Closes #200