### PR TITLE
include higher canary timeouts for UAA

### DIFF
--- a/cluster/operations/uaa.yml
+++ b/cluster/operations/uaa.yml
@@ -109,3 +109,9 @@
   value:
     name: uaa_encryption_key
     type: password
+    
+- type: replace
+  path: /instance_groups/name=web/update?
+  value:
+    update_watch_time: 1000-150000
+    canary_watch_time: 1000-150000


### PR DESCRIPTION
When using UAA (whether colocated or not), it can take awhile to come up when initially starting.
The timeout provided in the base config for concourse doesn't support this, and can more often than not, result in an error.

Closes #203