### PR TITLE
Ops File to enable garden.ini configuration.

### DIFF
--- a/cluster/operations/add-garden-config-ini.yml
+++ b/cluster/operations/add-garden-config-ini.yml
@@ -1,0 +1,4 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=worker/properties/garden?
+  value:
+    config_ini: ((worker_garden_config_ini))


### PR DESCRIPTION
This is a companion to https://github.com/concourse/concourse-bosh-release/pull/94
