### PR TITLE
add URL for bbr-sdk-release in backup-atc

### DIFF
--- a/cluster/operations/backup-atc.yml
+++ b/cluster/operations/backup-atc.yml
@@ -3,6 +3,7 @@
   value:
     name: backup-and-restore-sdk
     version: ((bbr_sdk_version))
+    url: https://bosh.io/d/github.com/cloudfoundry-incubator/backup-and-restore-sdk-release?v=((bbr_sdk_version))
 
 - type: replace
   path: /instance_groups/name=db/jobs/-


### PR DESCRIPTION
fixes concourse/concourse-bosh-deployment#77

This means that users consuming this ops file -- especially those following the docs at https://docs.pivotal.io/p-concourse/v5/installation/install-concourse-bosh/ -- can deploy without first uploading the release.
