### PR TITLE
Replaced deprecated log_retention spec with new one

### DIFF
--- a/cluster/operations/build-log-retention.yml
+++ b/cluster/operations/build-log-retention.yml
@@ -1,5 +1,5 @@
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/build_log_retention?
   value:
-    default: ((build_logs_default))
-    maximum: ((build_logs_maximum))
+    default_builds: ((build_logs_default))
+    maximum_builds: ((build_logs_maximum))


### PR DESCRIPTION
Hi,

according to the concourse bosh release, the used specs are deprecated (https://github.com/concourse/concourse-bosh-release/blob/master/jobs/web/spec#L1383-L1392). Therefore I adjusted them to use the recommended specs.

