### PR TITLE
Add  manifest for an external windows worker

### DIFF
--- a/cluster/external-windows-worker.yml
+++ b/cluster/external-windows-worker.yml
@@ -1,0 +1,42 @@
+name: ((deployment_name))
+
+releases:
+- name: concourse
+  version: ((concourse_version))
+  sha1: ((concourse_sha1))
+  url: https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=((concourse_version))
+- name: windows-utilities
+  version: ((windows_utilities_version))
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/windows-utilities-release?v=((windows_utilities_version))
+  sha1: ((windows_utilities_sha1))
+
+stemcells:
+- alias: windows
+  os: windows2019
+  version: latest
+
+instance_groups:
+- name: windows-worker
+  instances: ((instances))
+  vm_type: ((worker_vm_type))
+  stemcell: windows
+  networks: [{name: ((external_worker_network_name))}]
+  azs: ((azs))
+  jobs:
+  - name: enable_ssh
+    release: windows-utilities
+  - name: worker-windows
+    release: concourse
+    properties:
+      tags: ((worker_tags))
+      worker_gateway:
+        hosts: ["((tsa_host)):2222"]
+        host_public_key: ((tsa_host_key.public_key))
+        worker_key: ((worker_key))
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  serial: false
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000


### PR DESCRIPTION
Hi!

I recently needed to deploy an external windows worker. This turned out to require a lot of patching if one starts off with `external-worker.yml` manifest. While the ops files for `windows-worker.yml` and `windows-worker-ephemeral-disk.yml` will add the necessary sections to the manifest, because they are assumed largely to apply to the main concourse deployment, and not an external deployment, one still needs to manually craft an ops file to do the following things:

- remove the linux worker and stemcell definitions if they aren't needed
- add in the necessary properties to enable the remote worker to contact the `tsa` (`worker_gateway.hosts`, `worker_gateway.host_public_key`)

This PR adds a manifest specifically for deploying an external windows worker, taking inspiration and attempting to follow the pattern set in `external-worker.yml`.

It's still compatible with `windows-worker-ephemeral-disk.yml` if it is needed.