### PR TITLE
Add opsfile to enable containerd runtime

### DIFF
--- a/cluster/operations/runtime-containerd.yml
+++ b/cluster/operations/runtime-containerd.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=worker/properties/runtime?
+  value: containerd


### PR DESCRIPTION
containerd runtime support reached GA in [v7.0.0 release](https://github.com/concourse/concourse/releases/tag/v7.0.0). This ops file should help other teams change the default container runtime from Guardian to containerd.

Signed-off-by: Andrei Krasnitski <a.krasnitski@outlook.com>