### PR TITLE
Update tls.yml to not enable mTLS on the ATC

### DIFF
--- a/cluster/operations/mtls.yml
+++ b/cluster/operations/mtls.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=web/jobs/name=web/properties/tls?/cert
+  value: ((atc_tls))

--- a/cluster/operations/tls.yml
+++ b/cluster/operations/tls.yml
@@ -1,3 +1,5 @@
 - type: replace
-  path: /instance_groups/name=web/jobs/name=web/properties/tls?/cert?
-  value: ((atc_tls))
+  path: /instance_groups/name=web/jobs/name=web/properties/tls?/cert
+  value:
+    certificate: ((atc_tls.certificate))
+    private_key: ((atc_tls.private_key))


### PR DESCRIPTION
Per issue #233, this PR updates the `tls.yml` cluster ops-file to not include the CA certificate in the ATC configuration as this will enable mTLS as of v7.0.0. It also includes a new `mtls.yml` ops-file for users who do want to enable mTLS.

