### PR TITLE
Add keys for skip_email_verified_validation and skip_ssl_validation

### DIFF
--- a/cluster/operations/generic-oidc.yml
+++ b/cluster/operations/generic-oidc.yml
@@ -8,3 +8,5 @@
     groups_key: ((oidc.groups_key))
     display_name: ((oidc.display_name))
     user_name_key: ((oidc.user_name_key))
+    skip_email_verified_validation: ((oidc.skip_email_verified_validation))
+    skip_ssl_validation: ((oidc.skip_ssl_validation))


### PR DESCRIPTION
I added keys for `skip_email_verified_validation` and `skip_ssl_validation`.

https://bosh.io/jobs/web?source=github.com/concourse/concourse-bosh-release&version=7.4.0#:~:text=%5B%5D-,skip_email_verified_validation,Skip%20SSL%20validation.,-user_name_key