### PR TITLE
Update generic-oidc.yml with skip_email_verified_validation param

### DIFF
--- a/cluster/operations/generic-oidc.yml
+++ b/cluster/operations/generic-oidc.yml
@@ -8,3 +8,4 @@
     groups_key: ((oidc.groups_key))
     display_name: ((oidc.display_name))
     user_name_key: ((oidc.user_name_key))
+    skip_email_verified_validation: ((oidc.skip_email_verified_validation))


### PR DESCRIPTION
Azure Active Directory doesn't return email_verify flag after authentication. To skip the verification, need to turn this flag on. More on issue here: https://github.com/concourse/concourse/issues/6431