### PR TITLE
Replace `uaa.port` by `uaa.localhost_http_port` in uaa.yml.

### DIFF
--- a/cluster/operations/uaa.yml
+++ b/cluster/operations/uaa.yml
@@ -16,7 +16,7 @@
     properties:
       uaa:
         url: &uaa-url "((external_url)):8443"
-        port: 8181
+        localhost_http_port: 8181
         scim:
           users:
           - name: admin


### PR DESCRIPTION
Since UAA bosh release v73.0.0, `uaa.port` has been replaced by `uaa.localhost_http_port`.
- https://github.com/cloudfoundry/uaa-release/commit/3badc8082a5813919625dda9f9aff8efe5e0cd56

concourse-bosh-deployment starts explicitly including UAA versions since v5.8.1 which includes UAA v74.9.0.
- https://github.com/concourse/concourse-bosh-deployment/commit/feeb964a1be7a36a9598c5614e40e72d9d2179ea