### PR TITLE
Add containerd DNS ops file

### DIFF
--- a/cluster/operations/containerd-dns.yml
+++ b/cluster/operations/containerd-dns.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=worker/properties/containerd?/dns_servers?
+  value: ((containerd_dns_servers))


### PR DESCRIPTION
Currently there is no ops file to configure DNS for containerd runtime but just for garden. This PR should solve this issue.