### PR TITLE
fix ```external-postgres-tls.yml```

### DIFF
--- a/cluster/operations/external-postgres-tls.yml
+++ b/cluster/operations/external-postgres-tls.yml
@@ -1,7 +1,8 @@
 # requires the external-postgres.yml op file
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/postgresql/ca_cert?
-  value: ((postgres_ca_cert))
+  value:
+    certificate: ((postgres_ca_cert))
 - type: replace
   path: /instance_groups/name=web/jobs/name=web/properties/postgresql/sslmode?
   value: verify-ca


### PR DESCRIPTION
web job property `postgresql.ca_cert` requires field `certificate`:
- https://github.com/concourse/concourse-bosh-release/blob/v7.9.1/jobs/web/spec#L1258-L1262