### PR TITLE
Fix order of instance_groups

### DIFF
--- a/cluster/concourse.yml
+++ b/cluster/concourse.yml
@@ -16,6 +16,26 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=((postgres_version))
 
 instance_groups:
+- name: db
+  instances: 1
+  azs: ((azs))
+  networks: [{name: ((network_name))}]
+  stemcell: jammy
+  vm_type: ((db_vm_type))
+  persistent_disk_type: ((db_persistent_disk_type))
+  jobs:
+  - release: postgres
+    name: postgres
+    properties:
+      databases:
+        port: 5432
+        databases:
+        - name: &db_name atc
+        roles:
+        - &db_role
+          name: concourse
+          password: ((postgres_password))
+
 - name: web
   instances: 1
   azs: ((azs))
@@ -34,33 +54,13 @@ instance_groups:
       external_url: ((external_url))
 
       postgresql:
-        database: &db_name atc
-        role: &db_role
-          name: concourse
-          password: ((postgres_password))
+        database: *db_name
+        role: *db_role
 
       worker_gateway:
         host_key: ((tsa_host_key))
         authorized_keys: |
           ((worker_key.public_key))
-
-- name: db
-  instances: 1
-  azs: ((azs))
-  networks: [{name: ((network_name))}]
-  stemcell: jammy
-  vm_type: ((db_vm_type))
-  persistent_disk_type: ((db_persistent_disk_type))
-  jobs:
-  - release: postgres
-    name: postgres
-    properties:
-      databases:
-        port: 5432
-        databases:
-        - name: *db_name
-        roles:
-        - *db_role
 
 - name: worker
   instances: 1


### PR DESCRIPTION
### Reorder instance groups, so we do not see errors  when using `serial` dependancy. 

The same should also be fixed in the release tags for `7.13.0` and `7.13.1`  for the bosh deployment as it is currently breaking with them when using `serial` option. One might use `serial` due to issues like (https://github.com/concourse/concourse-bosh-release/issues/44).
In any case serial ensures that the instance groups are applied in the order they are defined in the manifest, whereas bosh deployment of Concourse at the moment deploys everything in parallel (serial: false). I suspect the issue is reproducible  for the new releases only, because in the past the web used `lib/pq` which retried in some way (didn't hard fail), whereas right now, the initial web VM fails as it cannot reach the (still not deployed) database and we never move on to the next (_db_) instance_group. In any case, I still think the database should be the first thing in the `concourse.yml` file that is defined, as the following require it anyway.

### Tests executed:
Functionally nothing changes and I validated it on a local bosh environment by generating a manifest from the new `concourse.yml` file.

References: More info on serial in https://bosh.io/docs/manifest-v2/#update (check serial property)